### PR TITLE
Add "TODO - cleanup" line to README

### DIFF
--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Literal
 
 from textual import on
 from textual.app import App, ComposeResult
@@ -20,6 +22,22 @@ from chud.widgets.session_list import SessionListView, SessionRow
 from chud.widgets.session_view import SessionView
 
 log = logging.getLogger(__name__)
+
+PromptKind = Literal["plan", "cleanup", "input"]
+
+
+@dataclass
+class PromptRequest:
+    """A pending blocking user-input request from one agent session.
+
+    Queued FIFO in ``ChudApp._prompt_queue`` so the first agent to ask for
+    input keeps the screen until its prompt is resolved, instead of being
+    covered by a later agent's modal.
+    """
+
+    session_id: str
+    kind: PromptKind
+    payload: dict[str, Any] = field(default_factory=dict)
 
 
 class ChudApp(App[None]):
@@ -51,6 +69,11 @@ class ChudApp(App[None]):
         self._selected_session_id: str | None = None
         self._open_plan_modals: set[str] = set()
         self._open_cleanup_modals: set[str] = set()
+        # FIFO queue of blocking user-input requests from agents. The first
+        # request is shown until resolved; later requests wait their turn so a
+        # newly-arrived modal can't cover one the user hasn't answered yet.
+        self._prompt_queue: list[PromptRequest] = []
+        self._prompt_active: PromptRequest | None = None
 
     # ------------------------------------------------------------------ layout
 
@@ -125,6 +148,7 @@ class ChudApp(App[None]):
         self._event_log.pop(sid, None)
         self._selected_session_id = None
         self.query_one(SessionView).show_session(None)
+        self._drop_session_prompts(sid)
 
     # ------------------------------------------------------------------ list selection
 
@@ -167,6 +191,15 @@ class ChudApp(App[None]):
             await sess.send_message(text)
         except Exception as e:
             self.notify(f"send_message failed: {e}", severity="error")
+            return
+        # If the active prompt was an "input" request from this session, the
+        # user has just answered it — advance the queue.
+        if (
+            self._prompt_active is not None
+            and self._prompt_active.kind == "input"
+            and self._prompt_active.session_id == sid
+        ):
+            self._resolve_active_prompt(self._prompt_active)
 
     # ------------------------------------------------------------------ event pump
 
@@ -192,9 +225,28 @@ class ChudApp(App[None]):
                 self.query_one(SessionView).update_header(sess.state)
 
         if event.kind == EventKind.PLAN_PROPOSED:
-            self._open_plan_modal(event.session_id, event.payload.get("plan", ""))
+            self._enqueue_prompt(
+                PromptRequest(
+                    session_id=event.session_id,
+                    kind="plan",
+                    payload={"plan": event.payload.get("plan", "")},
+                )
+            )
         elif event.kind == EventKind.CLEANUP_REQUESTED:
-            self._open_cleanup_modal(event.session_id)
+            self._enqueue_prompt(
+                PromptRequest(session_id=event.session_id, kind="cleanup")
+            )
+        elif event.kind == EventKind.NEEDS_USER_INPUT:
+            self._enqueue_prompt(
+                PromptRequest(
+                    session_id=event.session_id,
+                    kind="input",
+                    payload={
+                        "message": event.payload.get("message", ""),
+                        "reason": event.payload.get("reason", ""),
+                    },
+                )
+            )
         elif event.kind == EventKind.PR_PUBLISHED:
             url = event.payload.get("url", "")
             repo = event.payload.get("repo", "")
@@ -212,8 +264,78 @@ class ChudApp(App[None]):
                 f"[bold red]! PR failed:[/bold red] {repo or '(session)'}: {err}"
             )
 
-    def _open_plan_modal(self, session_id: str, plan_text: str) -> None:
+    # ------------------------------------------------------------------ prompt queue
+
+    def _enqueue_prompt(self, req: PromptRequest) -> None:
+        """Append a blocking user-input request to the FIFO queue.
+
+        Dedups against both the active prompt and anything already queued for
+        the same (session, kind) pair so duplicate events (e.g. a re-fired
+        notification hook) don't stack the same prompt twice. Triggers the
+        next-prompt dispatcher in case nothing is currently shown.
+        """
+        if (
+            self._prompt_active is not None
+            and self._prompt_active.session_id == req.session_id
+            and self._prompt_active.kind == req.kind
+        ):
+            return
+        if any(
+            p.session_id == req.session_id and p.kind == req.kind
+            for p in self._prompt_queue
+        ):
+            return
+        self._prompt_queue.append(req)
+        self._maybe_show_next_prompt()
+
+    def _maybe_show_next_prompt(self) -> None:
+        """If nothing is currently shown, pop the next request and show it."""
+        if self._prompt_active is not None:
+            return
+        # Skip requests for sessions that no longer exist (killed mid-queue).
+        while self._prompt_queue:
+            req = self._prompt_queue.pop(0)
+            if self.manager.sessions.get(req.session_id) is None:
+                continue
+            self._prompt_active = req
+            if req.kind == "plan":
+                self._show_plan_modal(req)
+            elif req.kind == "cleanup":
+                self._show_cleanup_modal(req)
+            elif req.kind == "input":
+                self._show_input_focus(req)
+            return
+
+    def _resolve_active_prompt(self, req: PromptRequest) -> None:
+        """Mark the active prompt resolved and advance the queue.
+
+        Idempotent: only clears the active slot if `req` is still the one
+        showing (a session-kill could have already swapped it out).
+        """
+        if self._prompt_active is req:
+            self._prompt_active = None
+        self._maybe_show_next_prompt()
+
+    def _drop_session_prompts(self, session_id: str) -> None:
+        """Remove any queued/active prompts for a session that's going away."""
+        self._prompt_queue = [
+            p for p in self._prompt_queue if p.session_id != session_id
+        ]
+        if (
+            self._prompt_active is not None
+            and self._prompt_active.session_id == session_id
+        ):
+            self._prompt_active = None
+            self._maybe_show_next_prompt()
+
+    # ------------------------------------------------------------------ prompt renderers
+
+    def _show_plan_modal(self, req: PromptRequest) -> None:
+        session_id = req.session_id
+        plan_text = req.payload.get("plan", "")
         if session_id in self._open_plan_modals:
+            # Should be impossible given the queue dedup above, but guard anyway.
+            self._resolve_active_prompt(req)
             return
         self._open_plan_modals.add(session_id)
 
@@ -233,14 +355,18 @@ class ChudApp(App[None]):
                     await sess.reject_plan()
             finally:
                 self._open_plan_modals.discard(session_id)
+                self._resolve_active_prompt(req)
 
         self.run_worker(show_modal(), exclusive=False)
 
-    def _open_cleanup_modal(self, session_id: str) -> None:
+    def _show_cleanup_modal(self, req: PromptRequest) -> None:
+        session_id = req.session_id
         if session_id in self._open_cleanup_modals:
+            self._resolve_active_prompt(req)
             return
         sess = self.manager.sessions.get(session_id)
         if sess is None:
+            self._resolve_active_prompt(req)
             return
         self._open_cleanup_modals.add(session_id)
         state = sess.state
@@ -258,10 +384,31 @@ class ChudApp(App[None]):
                 if self._selected_session_id == session_id:
                     self._selected_session_id = None
                     self.query_one(SessionView).show_session(None)
+                # Drop any other queued prompts (e.g. a stale PLAN_PROPOSED)
+                # for the now-killed session so the queue doesn't try to
+                # re-show them.
+                self._drop_session_prompts(session_id)
             finally:
                 self._open_cleanup_modals.discard(session_id)
+                self._resolve_active_prompt(req)
 
         self.run_worker(show_modal(), exclusive=False)
+
+    def _show_input_focus(self, req: PromptRequest) -> None:
+        """Auto-select the asking session and focus the input box.
+
+        Unlike the modal kinds, this prompt has no screen to wait on; it
+        resolves in ``on_input_submitted`` when the user actually replies.
+        """
+        if self.manager.sessions.get(req.session_id) is None:
+            self._resolve_active_prompt(req)
+            return
+        self._select_session(req.session_id)
+        try:
+            self.query_one(SessionView).input.focus()
+        except Exception:
+            # Focusing is best-effort; the prompt is still considered "shown".
+            pass
 
 
 def main() -> int:

--- a/src/chud/manager.py
+++ b/src/chud/manager.py
@@ -34,8 +34,10 @@ class SessionManager:
         # Sessions for which we've already fired DONE-side-effects, so re-emitted
         # STATUS_CHANGED(DONE) events (e.g. after a notification) don't re-trigger.
         self._done_handled: set[str] = set()
-        # Strong refs to in-flight PR-publish tasks so they aren't GC'd.
-        self._pr_tasks: set[asyncio.Task[None]] = set()
+        # Strong refs to in-flight DONE side-effect tasks (PR publish, then
+        # optional cleanup-broadcast) keyed by session id so kill_session can
+        # cancel a session's task in O(1).
+        self._pr_tasks: dict[str, asyncio.Task[None]] = {}
 
     # ------------------------------------------------------------------ subscribe
 
@@ -120,11 +122,19 @@ class SessionManager:
         sess = self.sessions.pop(session_id, None)
         task = self._fanout_tasks.pop(session_id, None)
         wt_mgr = self.worktrees.pop(session_id, None)
+        done_task = self._pr_tasks.pop(session_id, None)
         self._done_handled.discard(session_id)
         if task is not None and not task.done():
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
+        # Cancel any in-flight DONE side-effect (PR publish + queued cleanup
+        # broadcast) before we tear down the worktree, otherwise rmtree races
+        # with git push.
+        if done_task is not None and not done_task.done():
+            done_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await done_task
         if sess is not None:
             await sess.stop()
         if cleanup_workspace and wt_mgr is not None:
@@ -183,15 +193,29 @@ class SessionManager:
             return
         self._done_handled.add(sid)
         opts = sess.state.options or {}
-        if opts.get(OPT_MAKE_DRAFT_PR):
-            task = asyncio.create_task(
-                self._publish_prs(sess.state), name=f"chud-pr-{sid}"
-            )
-            self._pr_tasks.add(task)
-            task.add_done_callback(self._pr_tasks.discard)
-        if opts.get(OPT_SELF_CLEANUP):
+        make_pr = bool(opts.get(OPT_MAKE_DRAFT_PR))
+        do_cleanup = bool(opts.get(OPT_SELF_CLEANUP))
+        if not (make_pr or do_cleanup):
+            return
+        if not make_pr:
             await self._broadcast(
                 Event(session_id=sid, kind=EventKind.CLEANUP_REQUESTED, payload={})
+            )
+            return
+        task = asyncio.create_task(
+            self._finish_done(sess.state, do_cleanup), name=f"chud-done-{sid}"
+        )
+        self._pr_tasks[sid] = task
+        task.add_done_callback(lambda _t, s=sid: self._pr_tasks.pop(s, None))
+
+    async def _finish_done(self, state: SessionState, request_cleanup: bool) -> None:
+        # PR publish must complete before cleanup is offered, otherwise the
+        # cleanup modal can race with the still-running git push and the user
+        # ends up with neither a worktree nor a PR.
+        await self._publish_prs(state)
+        if request_cleanup:
+            await self._broadcast(
+                Event(session_id=state.id, kind=EventKind.CLEANUP_REQUESTED, payload={})
             )
 
     async def _publish_prs(self, state: SessionState) -> None:

--- a/src/chud/pr.py
+++ b/src/chud/pr.py
@@ -5,12 +5,17 @@ Triggered by ``SessionManager`` when a session reaches DONE and the
 against its origin's default branch. Failures are reported per-repo via
 ``PRResult`` (and surfaced to the UI as ``PR_FAILED`` events) so a single
 broken push doesn't sink the whole batch.
+
+Title and body prefer the agent's approved plan (a ``# Heading`` for the
+title, a ``## Context`` section for the body) over the raw initial prompt,
+so PRs read as summaries of *what was done* rather than verbatim user input.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -64,21 +69,83 @@ async def _default_branch(repo_path: Path) -> str:
     return "main"
 
 
+# Match a top-level "# heading" line (single hash, not ## or more). DOTALL is
+# unnecessary because we only consume up to the newline.
+_H1_RE = re.compile(r"^[ \t]*#[ \t]+(?P<title>.+?)[ \t]*$", re.MULTILINE)
+# Match a "## Context" heading and capture everything until the next "## " or EOF.
+_CONTEXT_RE = re.compile(
+    r"^[ \t]*##[ \t]+context[ \t]*$\s*(?P<body>.+?)(?=^[ \t]*##[ \t]+|\Z)",
+    re.MULTILINE | re.IGNORECASE | re.DOTALL,
+)
+
+
+def _extract_plan_title(plan_text: str) -> str | None:
+    """Return the first ``# Heading`` line of ``plan_text``, stripped, or None.
+
+    Skips ``##``/``###``/etc. — only the top-level title counts.
+    """
+    if not plan_text:
+        return None
+    m = _H1_RE.search(plan_text)
+    if not m:
+        return None
+    title = m.group("title").strip()
+    return title or None
+
+
+def _extract_plan_context(plan_text: str) -> str | None:
+    """Return the body of the first ``## Context`` section, stripped, or None."""
+    if not plan_text:
+        return None
+    m = _CONTEXT_RE.search(plan_text)
+    if not m:
+        return None
+    body = m.group("body").strip()
+    return body or None
+
+
+def _truncate_title(title: str) -> str:
+    if len(title) > _TITLE_LIMIT:
+        return title[: _TITLE_LIMIT - 1] + "…"
+    return title
+
+
 def _title_from_prompt(prompt: str) -> str:
+    """Fallback title derivation when no approved plan is available."""
     text = prompt.strip()
     if not text:
         return "chud session"
     first = text.splitlines()[0].strip() or "chud session"
-    if len(first) > _TITLE_LIMIT:
-        return first[: _TITLE_LIMIT - 1] + "…"
-    return first
+    return _truncate_title(first)
 
 
 def _body_from_prompt(session_id: str, prompt: str) -> str:
+    """Fallback body when no approved plan is available."""
     return (
         f"Draft PR opened by chud session `{session_id}`.\n\n"
         f"Initial prompt:\n\n```\n{prompt}\n```\n"
     )
+
+
+def _pick_title(state: SessionState) -> str:
+    """Prefer the approved plan's H1 heading; fall back to the prompt."""
+    if state.approved_plan:
+        plan_title = _extract_plan_title(state.approved_plan)
+        if plan_title:
+            return _truncate_title(plan_title)
+    return _title_from_prompt(state.initial_prompt)
+
+
+def _pick_body(state: SessionState) -> str:
+    """Prefer the plan's ``## Context`` section as the body lead, with a
+    small footer pointing back to the chud session id. Fall back to the
+    prompt-only body when no plan is available.
+    """
+    if state.approved_plan:
+        context = _extract_plan_context(state.approved_plan)
+        if context:
+            return f"{context}\n\n---\n*Draft PR opened by chud session `{state.id}`.*\n"
+    return _body_from_prompt(state.id, state.initial_prompt)
 
 
 async def publish_draft_prs(state: SessionState) -> list[PRResult]:
@@ -90,8 +157,8 @@ async def publish_draft_prs(state: SessionState) -> list[PRResult]:
     if shutil.which("gh") is None:
         return [PRResult(repo_label="", branch="", error="gh CLI not installed")]
 
-    title = _title_from_prompt(state.initial_prompt)
-    body = _body_from_prompt(state.id, state.initial_prompt)
+    title = _pick_title(state)
+    body = _pick_body(state)
     results: list[PRResult] = []
 
     for label, wt in state.attached_repos.items():

--- a/src/chud/session.py
+++ b/src/chud/session.py
@@ -65,8 +65,15 @@ class AgentSession:
 
         self.state.initial_prompt = prompt
 
+        # If exactly one repo is attached, run the agent inside that worktree so
+        # its tools see a real git checkout. With 0 or 2+ repos, fall back to
+        # the workspace root: 0 repos = scratch dir for non-repo work; 2+ repos
+        # = parent of all worktree subdirs so the agent can `cd` between them.
+        attached = list(self.state.attached_repos.values())
+        cwd = attached[0].worktree_path if len(attached) == 1 else self.state.workspace_dir
+
         options = ClaudeAgentOptions(
-            cwd=self.state.workspace_dir,
+            cwd=cwd,
             permission_mode="plan",
             can_use_tool=self._on_tool_request,
             hooks={
@@ -129,6 +136,10 @@ class AgentSession:
             return
         assert self._client is not None
         await self._client.set_permission_mode("acceptEdits")
+        # Persist the approved plan text so downstream consumers (PR title/body)
+        # can read it later, including across TUI restarts.
+        if self._pending_plan_text:
+            self.state.approved_plan = self._pending_plan_text
         self._plan_decision.set_result(PermissionResultAllow())
         self._plan_decision = None
         self._pending_plan_text = None

--- a/src/chud/state.py
+++ b/src/chud/state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 from platformdirs import user_data_dir
@@ -24,6 +25,10 @@ def sessions_file() -> Path:
     return data_root() / "sessions.json"
 
 
+def config_file() -> Path:
+    return data_root() / "config.json"
+
+
 def load_all() -> dict[str, SessionState]:
     path = sessions_file()
     if not path.exists():
@@ -37,3 +42,49 @@ def save_all(sessions: dict[str, SessionState]) -> None:
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps({sid: s.to_dict() for sid, s in sessions.items()}, indent=2))
     tmp.replace(path)
+
+
+def load_user_config() -> dict[str, bool]:
+    """Load persisted user defaults; return {} if missing or unreadable."""
+    path = config_file()
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text())
+    except Exception:
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def save_user_config(options: dict[str, bool]) -> None:
+    path = config_file()
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(options, indent=2))
+    tmp.replace(path)
+
+
+def user_default_options() -> dict[str, bool]:
+    """Registry defaults overlaid with the user's saved preferences."""
+    # Lazy import keeps the options → types → state graph acyclic.
+    from chud.options import normalize_options
+
+    return normalize_options(load_user_config())
+
+
+def get_recent_repo_paths() -> list[str]:
+    """Distinct repo paths from past sessions, most-recently-active first.
+
+    Reads `attached_repos` across every persisted `SessionState` and returns each
+    unique repo toplevel path (the dict keys, already `str(toplevel)` per
+    `WorktreeManager.attach_repo`). The list is sorted by the latest
+    `last_activity_at` of any session that referenced the repo, descending, so the
+    most-recently-touched repo comes first.
+    """
+    sessions = load_all()
+    last_seen: dict[str, datetime] = {}
+    for s in sessions.values():
+        for repo_key in s.attached_repos:
+            ts = s.last_activity_at
+            if repo_key not in last_seen or ts > last_seen[repo_key]:
+                last_seen[repo_key] = ts
+    return [p for p, _ in sorted(last_seen.items(), key=lambda kv: kv[1], reverse=True)]

--- a/src/chud/types.py
+++ b/src/chud/types.py
@@ -20,6 +20,7 @@ KEY_LAST_ACTIVITY_AT = "last_activity_at"
 KEY_PENDING_QUESTION = "pending_question"
 KEY_ERROR = "error"
 KEY_OPTIONS = "options"
+KEY_APPROVED_PLAN = "approved_plan"
 
 
 class SessionStatus(str, Enum):
@@ -66,6 +67,7 @@ class SessionState:
     pending_question: str | None = None
     error: str | None = None
     options: dict[str, bool] = field(default_factory=dict)
+    approved_plan: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -79,6 +81,7 @@ class SessionState:
             KEY_PENDING_QUESTION: self.pending_question,
             KEY_ERROR: self.error,
             KEY_OPTIONS: dict(self.options),
+            KEY_APPROVED_PLAN: self.approved_plan,
         }
 
     @classmethod
@@ -99,6 +102,7 @@ class SessionState:
             pending_question=d.get(KEY_PENDING_QUESTION),
             error=d.get(KEY_ERROR),
             options=normalize_options(d.get(KEY_OPTIONS)),
+            approved_plan=d.get(KEY_APPROVED_PLAN),
         )
 
 

--- a/src/chud/widgets/new_session_modal.py
+++ b/src/chud/widgets/new_session_modal.py
@@ -2,13 +2,9 @@ from __future__ import annotations
 
 import subprocess
 from dataclasses import dataclass, field
-import subprocess
-from dataclasses import dataclass, field
 from pathlib import Path
 
 from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
@@ -65,7 +61,6 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
         width: 90%;
         max-width: 100;
         height: 32;
-        height: 32;
         background: $surface;
         border: round $accent;
         padding: 1 2;
@@ -78,7 +73,6 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
         margin-bottom: 1;
     }
     NewSessionModal TextArea {
-        height: 8;
         height: 8;
         margin-bottom: 1;
     }
@@ -113,8 +107,6 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
     """
 
     BINDINGS = [
-        Binding("escape", "cancel", "Cancel"),
-        Binding("f2", "start", "Start", priority=True),
         Binding("escape", "cancel", "Cancel"),
         Binding("f2", "start", "Start", priority=True),
     ]
@@ -168,9 +160,6 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
     def action_start(self) -> None:
         self._submit()
 
-    def action_start(self) -> None:
-        self._submit()
-
     def on_mount(self) -> None:
         self.query_one("#repo", Input).focus()
 
@@ -180,13 +169,6 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
         if not prompt:
             return
         repo_path = Path(repo_str).expanduser() if repo_str else None
-        options = {
-            opt.id: self.query_one(f"#opt-{opt.id}", Checkbox).value
-            for opt in SESSION_OPTIONS
-        }
-        self.dismiss(
-            NewSessionResult(repo_path=repo_path, prompt=prompt, options=options)
-        )
         options = {
             opt.id: self.query_one(f"#opt-{opt.id}", Checkbox).value
             for opt in SESSION_OPTIONS

--- a/src/chud/widgets/new_session_modal.py
+++ b/src/chud/widgets/new_session_modal.py
@@ -2,22 +2,28 @@ from __future__ import annotations
 
 import subprocess
 from dataclasses import dataclass, field
+import subprocess
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
+from textual.suggester import SuggestFromList
 from textual.widgets import Button, Checkbox, Input, Label, Static, TextArea
 
-from chud.options import SESSION_OPTIONS, default_options
+from chud.options import SESSION_OPTIONS
+from chud.state import get_recent_repo_paths, save_user_config, user_default_options
 
 
 @dataclass
 class NewSessionResult:
     repo_path: Path | None
     prompt: str
-    options: dict[str, bool] = field(default_factory=default_options)
+    options: dict[str, bool] = field(default_factory=user_default_options)
 
 
 def _detect_cwd_repo() -> str:
@@ -36,6 +42,18 @@ def _detect_cwd_repo() -> str:
     return ""
 
 
+def _safe_recent_repos() -> list[str]:
+    """Return recent repo paths for autocomplete, swallowing any load errors.
+
+    The modal must open even if `sessions.json` is missing or malformed, so we
+    fall back to an empty list and let the suggester silently no-op.
+    """
+    try:
+        return get_recent_repo_paths()
+    except Exception:
+        return []
+
+
 class NewSessionModal(ModalScreen[NewSessionResult | None]):
     """Prompt user for an optional repo path + an initial prompt for a new session."""
 
@@ -46,6 +64,7 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
     NewSessionModal > Vertical {
         width: 90%;
         max-width: 100;
+        height: 32;
         height: 32;
         background: $surface;
         border: round $accent;
@@ -59,6 +78,7 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
         margin-bottom: 1;
     }
     NewSessionModal TextArea {
+        height: 8;
         height: 8;
         margin-bottom: 1;
     }
@@ -95,36 +115,58 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
         Binding("f2", "start", "Start", priority=True),
+        Binding("escape", "cancel", "Cancel"),
+        Binding("f2", "start", "Start", priority=True),
     ]
 
     def compose(self) -> ComposeResult:
         with Vertical():
             yield Static("[bold]New session[/bold]")
-            yield Label("Repo path (optional, leave blank for none):")
-            yield Input(value=_detect_cwd_repo(), placeholder="/path/to/repo", id="repo")
+            yield Label("Repo path (optional — Tab/→ to accept suggestion):")
+            yield Input(
+                value=_detect_cwd_repo(),
+                placeholder="/path/to/repo",
+                id="repo",
+                suggester=SuggestFromList(_safe_recent_repos(), case_sensitive=True),
+            )
             yield Label("Initial prompt:")
             yield TextArea("", id="prompt")
+            defaults = user_default_options()
             with VerticalScroll(id="options-group"):
                 yield Label("Options")
                 for opt in SESSION_OPTIONS:
                     yield Checkbox(
                         opt.label,
-                        value=opt.default,
+                        value=defaults[opt.id],
                         id=f"opt-{opt.id}",
                         tooltip=opt.description,
                     )
             with Horizontal(id="buttons"):
                 yield Button("Cancel (Esc)", id="cancel")
+                yield Button("Save as defaults", id="save-defaults")
                 yield Button("Start (F2)", id="start", variant="success")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "cancel":
             self.dismiss(None)
+        elif event.button.id == "save-defaults":
+            self._save_defaults()
         elif event.button.id == "start":
             self._submit()
 
+    def _save_defaults(self) -> None:
+        options = {
+            opt.id: self.query_one(f"#opt-{opt.id}", Checkbox).value
+            for opt in SESSION_OPTIONS
+        }
+        save_user_config(options)
+        self.app.notify("Saved as defaults.")
+
     def action_cancel(self) -> None:
         self.dismiss(None)
+
+    def action_start(self) -> None:
+        self._submit()
 
     def action_start(self) -> None:
         self._submit()
@@ -138,6 +180,13 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
         if not prompt:
             return
         repo_path = Path(repo_str).expanduser() if repo_str else None
+        options = {
+            opt.id: self.query_one(f"#opt-{opt.id}", Checkbox).value
+            for opt in SESSION_OPTIONS
+        }
+        self.dismiss(
+            NewSessionResult(repo_path=repo_path, prompt=prompt, options=options)
+        )
         options = {
             opt.id: self.query_one(f"#opt-{opt.id}", Checkbox).value
             for opt in SESSION_OPTIONS

--- a/src/chud/worktree.py
+++ b/src/chud/worktree.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -9,6 +10,36 @@ from chud.types import SessionState, Worktree
 
 class WorktreeError(RuntimeError):
     pass
+
+
+_SLUG_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_SLUG_MAX_LEN = 40
+
+
+def _slugify(text: str, max_len: int = _SLUG_MAX_LEN) -> str:
+    """Make ``text`` safe for a git branch / filesystem path segment.
+
+    Lowercases, replaces runs of non-alphanumerics with ``-``, strips leading
+    and trailing ``-``, and truncates at the last ``-`` boundary that fits in
+    ``max_len`` (falling back to a hard cut). Returns ``""`` if nothing
+    survives normalization (e.g. emoji-only input) — callers decide the
+    fallback name in that case.
+    """
+    if not text:
+        return ""
+    # Take only the first line; slugs from multi-line prompts get noisy fast.
+    first_line = text.splitlines()[0]
+    normalized = _SLUG_NON_ALNUM.sub("-", first_line.lower()).strip("-")
+    if not normalized:
+        return ""
+    if len(normalized) <= max_len:
+        return normalized
+    truncated = normalized[:max_len]
+    # Prefer to cut on a hyphen boundary so we don't slice a word in half.
+    last_hyphen = truncated.rfind("-")
+    if last_hyphen >= max_len // 2:
+        truncated = truncated[:last_hyphen]
+    return truncated.strip("-") or normalized[:max_len]
 
 
 def is_git_repo(path: Path) -> bool:
@@ -61,7 +92,8 @@ class WorktreeManager:
             i += 1
 
         worktree_path = self.session.workspace_dir / wt_dir_name
-        branch = f"chud/{self.session.id}"
+        slug = _slugify(self.session.initial_prompt) or "session"
+        branch = f"chud/{slug}-{self.session.id}"
 
         # if branch already exists in target repo (rare; same session attaching a repo
         # we've previously detached and re-attached), reuse it

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -221,6 +221,33 @@ async def test_new_session_modal_mounts_and_renders():
         _force_render(modal)
 
 
+async def test_new_session_modal_renders_with_recent_repo_suggestions(monkeypatch):
+    """The repo Input is wired to a SuggestFromList of recent repos.
+
+    Force a non-empty recent-repo list and confirm the modal still mounts and
+    that the repo Input has a suggester attached with those entries — i.e. the
+    autocomplete path doesn't crash with real suggestions in play.
+    """
+    from textual.suggester import SuggestFromList
+    from textual.widgets import Input
+
+    from chud.widgets import new_session_modal as nsm_mod
+
+    recents = ["/tmp/repo-a", "/tmp/repo-b"]
+    monkeypatch.setattr(nsm_mod, "_safe_recent_repos", lambda: recents)
+
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal())
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+        repo_input = modal.query_one("#repo", Input)
+        assert isinstance(repo_input.suggester, SuggestFromList)
+        _force_render(modal)
+
+
 async def test_attach_repo_modal_mounts_and_renders():
     app = ChudApp()
     async with app.run_test() as pilot:

--- a/tests/test_manager_done_hooks.py
+++ b/tests/test_manager_done_hooks.py
@@ -7,6 +7,7 @@ STATUS_CHANGED(DONE) event.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ import pytest
 from chud import pr as pr_mod
 from chud.manager import SessionManager
 from chud.options import OPT_MAKE_DRAFT_PR, OPT_SELF_CLEANUP
+from chud.pr import PRResult
 from chud.session import AgentSession
 from chud.types import Event, EventKind, SessionState, SessionStatus
 from chud.worktree import WorktreeManager
@@ -87,7 +89,7 @@ async def test_done_with_make_draft_pr_invokes_publisher(tmp_path, monkeypatch):
     await mgr._handle_event(_done_event(sess.state.id), sess)
 
     # _on_session_done schedules an asyncio task; await pending tasks.
-    pending = list(mgr._pr_tasks)
+    pending = list(mgr._pr_tasks.values())
     for task in pending:
         await task
 
@@ -167,3 +169,73 @@ async def test_kill_session_default_does_not_cleanup(tmp_path, monkeypatch):
     await mgr.kill_session(sess.state.id)
 
     assert cleanup_calls == []
+
+
+@pytest.mark.asyncio
+async def test_done_with_pr_and_cleanup_orders_events(tmp_path, monkeypatch):
+    """CLEANUP_REQUESTED must be broadcast only after publish_draft_prs returns.
+
+    Locks the bug where cleanup raced PR publish, wiping the worktree before
+    git push could finish.
+    """
+    mgr = SessionManager()
+    sess = _make_session(
+        {OPT_MAKE_DRAFT_PR: True, OPT_SELF_CLEANUP: True}, tmp_path
+    )
+    mgr.sessions[sess.state.id] = sess
+    monkeypatch.setattr(mgr, "_persist", lambda: None)
+
+    async def fake_publish(state):
+        for _ in range(3):
+            await asyncio.sleep(0)
+        return [PRResult(repo_label="r", branch="b", url="https://example/pr/1")]
+
+    monkeypatch.setattr(pr_mod, "publish_draft_prs", fake_publish)
+
+    queue = mgr.subscribe()
+    await mgr._handle_event(_done_event(sess.state.id), sess)
+
+    for task in list(mgr._pr_tasks.values()):
+        await task
+
+    kinds: list[EventKind] = []
+    while not queue.empty():
+        kinds.append(queue.get_nowait().kind)
+
+    assert EventKind.PR_PUBLISHED in kinds
+    assert EventKind.CLEANUP_REQUESTED in kinds
+    assert kinds.index(EventKind.PR_PUBLISHED) < kinds.index(
+        EventKind.CLEANUP_REQUESTED
+    )
+
+
+@pytest.mark.asyncio
+async def test_done_with_pr_failure_still_emits_cleanup(tmp_path, monkeypatch):
+    """If PR publish raises, cleanup is still offered (after PR_FAILED)."""
+    mgr = SessionManager()
+    sess = _make_session(
+        {OPT_MAKE_DRAFT_PR: True, OPT_SELF_CLEANUP: True}, tmp_path
+    )
+    mgr.sessions[sess.state.id] = sess
+    monkeypatch.setattr(mgr, "_persist", lambda: None)
+
+    async def boom(state):
+        raise RuntimeError("publish exploded")
+
+    monkeypatch.setattr(pr_mod, "publish_draft_prs", boom)
+
+    queue = mgr.subscribe()
+    await mgr._handle_event(_done_event(sess.state.id), sess)
+
+    for task in list(mgr._pr_tasks.values()):
+        await task
+
+    kinds: list[EventKind] = []
+    while not queue.empty():
+        kinds.append(queue.get_nowait().kind)
+
+    assert kinds.count(EventKind.CLEANUP_REQUESTED) == 1
+    assert EventKind.PR_FAILED in kinds
+    assert kinds.index(EventKind.PR_FAILED) < kinds.index(
+        EventKind.CLEANUP_REQUESTED
+    )

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -8,18 +8,22 @@ from chud import pr as pr_mod
 from chud.types import SessionState, Worktree
 
 
-def _state_with_one_repo() -> SessionState:
+def _state_with_one_repo(approved_plan: str | None = None) -> SessionState:
     s = SessionState(
         id="sess1",
         workspace_dir=Path("/tmp/chud-ws/sess1"),
         initial_prompt="add a foo",
+        approved_plan=approved_plan,
     )
     s.attached_repos["myrepo"] = Worktree(
         repo_path=Path("/tmp/myrepo"),
         worktree_path=Path("/tmp/chud-ws/sess1/myrepo"),
-        branch="chud/sess1",
+        branch="chud/add-a-foo-sess1",
     )
     return s
+
+
+# --- fallback path: prompt-only ----------------------------------------------
 
 
 def test_title_from_prompt_uses_first_line():
@@ -42,6 +46,100 @@ def test_body_includes_session_id_and_prompt():
     body = pr_mod._body_from_prompt("abcdef", "do the thing")
     assert "abcdef" in body
     assert "do the thing" in body
+
+
+def test_pick_title_falls_back_to_prompt_when_no_plan():
+    s = _state_with_one_repo()
+    assert pr_mod._pick_title(s) == "add a foo"
+
+
+def test_pick_body_falls_back_to_prompt_when_no_plan():
+    s = _state_with_one_repo()
+    body = pr_mod._pick_body(s)
+    assert "sess1" in body
+    assert "add a foo" in body
+
+
+# --- plan-driven path --------------------------------------------------------
+
+
+def test_extract_plan_title_finds_h1():
+    plan = "# Add auth feature\n\n## Context\n\nWhy.\n"
+    assert pr_mod._extract_plan_title(plan) == "Add auth feature"
+
+
+def test_extract_plan_title_ignores_h2_and_deeper():
+    plan = "## Context\n\nReason.\n\n# Real Title\n\n## Approach\n"
+    assert pr_mod._extract_plan_title(plan) == "Real Title"
+
+
+def test_extract_plan_title_returns_none_when_missing():
+    assert pr_mod._extract_plan_title("no headings here") is None
+    assert pr_mod._extract_plan_title("") is None
+
+
+def test_extract_plan_context_captures_section_body():
+    plan = (
+        "# Title\n\n"
+        "## Context\n\n"
+        "First paragraph.\n\nSecond paragraph.\n\n"
+        "## Approach\n\nDo X.\n"
+    )
+    body = pr_mod._extract_plan_context(plan)
+    assert body is not None
+    assert body.startswith("First paragraph.")
+    assert "Second paragraph." in body
+    assert "Do X." not in body
+    assert "## Approach" not in body
+
+
+def test_extract_plan_context_case_insensitive_heading():
+    plan = "# T\n\n## context\n\nlowercase heading body.\n\n## Approach\n"
+    assert pr_mod._extract_plan_context(plan) == "lowercase heading body."
+
+
+def test_extract_plan_context_returns_none_when_missing():
+    plan = "# Title\n\n## Approach\n\nDo X.\n"
+    assert pr_mod._extract_plan_context(plan) is None
+
+
+def test_pick_title_uses_plan_heading_when_present():
+    s = _state_with_one_repo(approved_plan="# Add auth feature\n\n## Context\n\nWhy.\n")
+    assert pr_mod._pick_title(s) == "Add auth feature"
+
+
+def test_pick_title_truncates_long_plan_heading():
+    long_title = "# " + "x" * 200 + "\n"
+    s = _state_with_one_repo(approved_plan=long_title)
+    out = pr_mod._pick_title(s)
+    assert len(out) <= 72
+    assert out.endswith("…")
+
+
+def test_pick_title_falls_back_when_plan_has_no_h1():
+    s = _state_with_one_repo(approved_plan="## Context\n\nNo H1 here.\n")
+    assert pr_mod._pick_title(s) == "add a foo"
+
+
+def test_pick_body_uses_plan_context_when_present():
+    plan = "# Title\n\n## Context\n\nBecause reasons.\n\n## Approach\n\nDo X.\n"
+    s = _state_with_one_repo(approved_plan=plan)
+    body = pr_mod._pick_body(s)
+    assert body.startswith("Because reasons.")
+    assert "## Approach" not in body
+    assert "Do X." not in body
+    # Footer references the chud session id.
+    assert "sess1" in body
+    # Verbatim prompt should NOT lead the body anymore.
+    assert not body.startswith("Draft PR opened by chud session")
+
+
+def test_pick_body_falls_back_when_plan_missing_context():
+    s = _state_with_one_repo(approved_plan="# Title\n\n## Approach\n\nDo X.\n")
+    body = pr_mod._pick_body(s)
+    # Falls back to the legacy boilerplate body.
+    assert body.startswith("Draft PR opened by chud session")
+    assert "add a foo" in body
 
 
 @pytest.mark.asyncio
@@ -103,7 +201,7 @@ async def test_publish_draft_prs_happy_path(monkeypatch):
     assert len(results) == 1
     assert results[0].error is None
     assert results[0].url == "https://github.com/x/y/pull/42"
-    assert results[0].branch == "chud/sess1"
+    assert results[0].branch == "chud/add-a-foo-sess1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_prompt_queue.py
+++ b/tests/test_prompt_queue.py
@@ -1,0 +1,279 @@
+"""FIFO queueing of blocking user-input prompts in ChudApp.
+
+These tests verify that when multiple agent sessions emit blocking prompts
+(PLAN_PROPOSED, CLEANUP_REQUESTED, NEEDS_USER_INPUT), the first prompt stays
+visible until the user answers it, then the next one appears — instead of the
+latest modal covering whichever the user hasn't answered yet.
+
+We don't spin up real ClaudeSDKClient instances; we manually populate
+``app.manager.sessions`` with synthetic ``AgentSession`` objects so the queue
+dispatcher's ``manager.sessions.get(sid)`` checks pass, then drive
+``app._on_event`` directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chud.app import ChudApp
+from chud.session import AgentSession
+from chud.types import Event, EventKind, SessionState, SessionStatus
+from chud.widgets.cleanup_confirmation_modal import CleanupConfirmationModal
+from chud.widgets.plan_modal import PlanApprovalModal
+
+
+def _register_session(app: ChudApp, sid: str, tmp_path: Path) -> AgentSession:
+    """Drop a stub AgentSession into the manager so queue checks pass.
+
+    Queue logic only inspects ``app.manager.sessions`` — we don't need the
+    SessionListView row or a real SDK client for these tests.
+    """
+    state = SessionState(
+        id=sid,
+        workspace_dir=tmp_path / sid,
+        status=SessionStatus.EXECUTING,
+        initial_prompt=f"prompt {sid}",
+    )
+    state.workspace_dir.mkdir(parents=True, exist_ok=True)
+    sess = AgentSession(state, model=None)
+    app.manager.sessions[sid] = sess
+    return sess
+
+
+def _plan_event(sid: str, plan: str = "do the thing") -> Event:
+    return Event(
+        session_id=sid,
+        kind=EventKind.PLAN_PROPOSED,
+        payload={"plan": plan},
+    )
+
+
+def _input_event(sid: str, message: str = "what now?") -> Event:
+    return Event(
+        session_id=sid,
+        kind=EventKind.NEEDS_USER_INPUT,
+        payload={"reason": "notification", "message": message},
+    )
+
+
+def _cleanup_event(sid: str) -> Event:
+    return Event(session_id=sid, kind=EventKind.CLEANUP_REQUESTED)
+
+
+def _count_modals(app: ChudApp, modal_cls: type) -> int:
+    return sum(1 for s in app.screen_stack if isinstance(s, modal_cls))
+
+
+@pytest.mark.asyncio
+async def test_two_plan_proposed_events_queue_modals_one_at_a_time(tmp_path):
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        _register_session(app, "sess-a", tmp_path)
+        _register_session(app, "sess-b", tmp_path)
+
+        app._on_event(_plan_event("sess-a", "plan A"))
+        app._on_event(_plan_event("sess-b", "plan B"))
+        await pilot.pause()
+
+        # Only one plan modal should be on the stack; the other waits in queue.
+        assert _count_modals(app, PlanApprovalModal) == 1
+        assert app._prompt_active is not None
+        assert app._prompt_active.session_id == "sess-a"
+        assert [p.session_id for p in app._prompt_queue] == ["sess-b"]
+
+        # The visible modal is for sess-a (the first to ask).
+        modal = app.screen
+        assert isinstance(modal, PlanApprovalModal)
+        assert modal.session_id == "sess-a"
+
+        # Approve sess-a's plan via the "a" key. After it resolves, the queued
+        # sess-b modal should appear automatically.
+        await pilot.press("a")
+        await pilot.pause()
+        await pilot.pause()  # give the worker an extra tick to advance the queue
+
+        assert _count_modals(app, PlanApprovalModal) == 1
+        modal2 = app.screen
+        assert isinstance(modal2, PlanApprovalModal)
+        assert modal2.session_id == "sess-b"
+        assert app._prompt_queue == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_plan_proposed_for_same_session_enqueues_once(tmp_path):
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        _register_session(app, "sess-a", tmp_path)
+
+        app._on_event(_plan_event("sess-a"))
+        app._on_event(_plan_event("sess-a"))  # duplicate
+        app._on_event(_plan_event("sess-a"))  # duplicate
+        await pilot.pause()
+
+        assert _count_modals(app, PlanApprovalModal) == 1
+        # Active is sess-a, queue should be empty (dedup against active).
+        assert app._prompt_active is not None
+        assert app._prompt_active.session_id == "sess-a"
+        assert app._prompt_queue == []
+
+
+@pytest.mark.asyncio
+async def test_input_request_auto_selects_session_and_advances_on_reply(tmp_path):
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        _register_session(app, "sess-a", tmp_path)
+        _register_session(app, "sess-b", tmp_path)
+        # Pre-select b so we can confirm the input event flips selection to a.
+        app._select_session("sess-b")
+        await pilot.pause()
+        assert app._selected_session_id == "sess-b"
+
+        app._on_event(_input_event("sess-a", "need clarification"))
+        await pilot.pause()
+
+        # NEEDS_USER_INPUT auto-selects the asking session.
+        assert app._selected_session_id == "sess-a"
+        assert app._prompt_active is not None
+        assert app._prompt_active.kind == "input"
+        assert app._prompt_active.session_id == "sess-a"
+
+        # Now sess-b also asks. b should queue behind a.
+        app._on_event(_input_event("sess-b", "and me too"))
+        await pilot.pause()
+
+        assert app._selected_session_id == "sess-a"  # still a
+        assert [p.session_id for p in app._prompt_queue] == ["sess-b"]
+
+
+@pytest.mark.asyncio
+async def test_plan_then_input_for_different_session_queues_correctly(tmp_path):
+    """Cross-kind FIFO: a plan modal in front, an input request behind it."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        sess_a = _register_session(app, "sess-a", tmp_path)
+        sess_b = _register_session(app, "sess-b", tmp_path)
+
+        # Stub the SDK calls that the plan modal would trigger on approve.
+        async def noop_approve():
+            return None
+
+        async def noop_reject(reason: str | None = None):
+            return None
+
+        sess_a.approve_plan = noop_approve  # type: ignore[method-assign]
+        sess_a.reject_plan = noop_reject  # type: ignore[method-assign]
+
+        app._on_event(_plan_event("sess-a"))
+        app._on_event(_input_event("sess-b"))
+        await pilot.pause()
+
+        assert _count_modals(app, PlanApprovalModal) == 1
+        assert app._prompt_active.kind == "plan"
+        assert app._prompt_active.session_id == "sess-a"
+        assert [(p.kind, p.session_id) for p in app._prompt_queue] == [
+            ("input", "sess-b")
+        ]
+
+        # Reject sess-a's plan (escape key). Then the input request should
+        # become active and selection should auto-flip to sess-b.
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert _count_modals(app, PlanApprovalModal) == 0
+        assert app._prompt_active is not None
+        assert app._prompt_active.kind == "input"
+        assert app._prompt_active.session_id == "sess-b"
+        assert app._selected_session_id == "sess-b"
+
+
+@pytest.mark.asyncio
+async def test_killed_session_with_queued_prompt_is_skipped(tmp_path):
+    """If a session is killed while its prompt is queued (not active), the
+    dispatcher must skip it when its turn comes — not show a stale modal."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        _register_session(app, "sess-a", tmp_path)
+        _register_session(app, "sess-b", tmp_path)
+        _register_session(app, "sess-c", tmp_path)
+
+        app._on_event(_plan_event("sess-a"))
+        app._on_event(_plan_event("sess-b"))
+        app._on_event(_plan_event("sess-c"))
+        await pilot.pause()
+
+        # a is active; b and c are queued.
+        assert app._prompt_active.session_id == "sess-a"
+        assert [p.session_id for p in app._prompt_queue] == ["sess-b", "sess-c"]
+
+        # Drop sess-b directly from manager (simulates kill while queued) and
+        # also via _drop_session_prompts so the queue is pruned.
+        app.manager.sessions.pop("sess-b")
+        app._drop_session_prompts("sess-b")
+
+        # Resolve sess-a — the queue should jump to sess-c, skipping b.
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+
+        modal = app.screen
+        assert isinstance(modal, PlanApprovalModal)
+        assert modal.session_id == "sess-c"
+        assert app._prompt_queue == []
+
+
+@pytest.mark.asyncio
+async def test_active_prompt_session_killed_advances_queue(tmp_path):
+    """Killing the session whose prompt is currently active drops the active
+    slot and immediately surfaces the next queued prompt."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        _register_session(app, "sess-a", tmp_path)
+        _register_session(app, "sess-b", tmp_path)
+
+        app._on_event(_plan_event("sess-a"))
+        app._on_event(_plan_event("sess-b"))
+        await pilot.pause()
+
+        assert app._prompt_active.session_id == "sess-a"
+
+        # Simulate the active session being killed out from under the modal.
+        app.manager.sessions.pop("sess-a")
+        app._drop_session_prompts("sess-a")
+        await pilot.pause()
+
+        # Queue should have advanced to sess-b. (The sess-a modal screen may
+        # still be on the stack until its worker unwinds, but the active
+        # PromptRequest tracking should reflect sess-b.)
+        assert app._prompt_active is not None
+        assert app._prompt_active.session_id == "sess-b"
+        assert app._prompt_queue == []
+
+
+@pytest.mark.asyncio
+async def test_cleanup_request_queues_behind_active_plan(tmp_path):
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        _register_session(app, "sess-a", tmp_path)
+        _register_session(app, "sess-b", tmp_path)
+
+        app._on_event(_plan_event("sess-a"))
+        app._on_event(_cleanup_event("sess-b"))
+        await pilot.pause()
+
+        assert app._prompt_active.kind == "plan"
+        assert app._prompt_active.session_id == "sess-a"
+        assert [(p.kind, p.session_id) for p in app._prompt_queue] == [
+            ("cleanup", "sess-b")
+        ]
+        assert _count_modals(app, PlanApprovalModal) == 1
+        assert _count_modals(app, CleanupConfirmationModal) == 0

--- a/tests/test_session_cwd.py
+++ b/tests/test_session_cwd.py
@@ -1,0 +1,106 @@
+"""Tests for AgentSession.start() cwd derivation.
+
+Regression: agents used to launch with cwd=workspace_dir (the parent of the
+worktree) instead of the worktree path itself, which made them edit the source
+repo instead of the worktree. start() now picks the worktree path when
+exactly one repo is attached, and falls back to workspace_dir for the
+0-repo and ≥2-repo cases.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from chud.session import AgentSession
+from chud.types import SessionState, Worktree
+
+
+class _CapturingClient:
+    """Stand-in for ClaudeSDKClient that records the options it was constructed with."""
+
+    last_options = None
+
+    def __init__(self, options) -> None:
+        type(self).last_options = options
+
+    async def connect(self) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def interrupt(self) -> None:
+        pass
+
+    async def query(self, *_a, **_kw) -> None:
+        pass
+
+    async def receive_messages(self):
+        await asyncio.Event().wait()
+        if False:
+            yield  # pragma: no cover
+
+
+@pytest.fixture
+def patched_client(monkeypatch):
+    _CapturingClient.last_options = None
+    monkeypatch.setattr("chud.session.ClaudeSDKClient", _CapturingClient)
+    return _CapturingClient
+
+
+def _state(workspace: Path, repos: list[Worktree] | None = None) -> SessionState:
+    st = SessionState(id="t1", workspace_dir=workspace)
+    for wt in repos or []:
+        st.attached_repos[str(wt.repo_path)] = wt
+    return st
+
+
+async def test_start_with_no_repos_uses_workspace_dir(tmp_path, patched_client):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    sess = AgentSession(_state(workspace))
+    try:
+        await sess.start("hello")
+        assert patched_client.last_options.cwd == workspace
+    finally:
+        await sess.stop()
+
+
+async def test_start_with_single_repo_uses_worktree_path(tmp_path, patched_client):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    repo = tmp_path / "src"
+    wt_path = workspace / "src"
+    wt_path.mkdir()
+    wt = Worktree(repo_path=repo, worktree_path=wt_path, branch="chud/x-t1")
+
+    sess = AgentSession(_state(workspace, [wt]))
+    try:
+        await sess.start("hello")
+        assert patched_client.last_options.cwd == wt_path
+    finally:
+        await sess.stop()
+
+
+async def test_start_with_two_repos_uses_workspace_dir(tmp_path, patched_client):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    wt1 = Worktree(
+        repo_path=tmp_path / "a",
+        worktree_path=workspace / "a",
+        branch="chud/x-t1",
+    )
+    wt2 = Worktree(
+        repo_path=tmp_path / "b",
+        worktree_path=workspace / "b",
+        branch="chud/x-t1",
+    )
+    sess = AgentSession(_state(workspace, [wt1, wt2]))
+    try:
+        await sess.start("hello")
+        assert patched_client.last_options.cwd == workspace
+    finally:
+        await sess.stop()

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -66,3 +66,33 @@ def test_session_state_drops_unknown_persisted_options():
     s2 = SessionState.from_dict(d)
     assert "some_removed_option" not in s2.options
     assert s2.options[OPT_SELF_CLEANUP] is True
+
+
+def test_session_state_roundtrips_approved_plan():
+    plan = "# Add foo\n\n## Context\n\nWe need foo because reasons.\n"
+    s = SessionState(
+        id="abc123",
+        workspace_dir=Path("/tmp/chud-ws/abc123"),
+        approved_plan=plan,
+    )
+    d = s.to_dict()
+    assert d["approved_plan"] == plan
+    s2 = SessionState.from_dict(d)
+    assert s2.approved_plan == plan
+
+
+def test_legacy_session_without_approved_plan_loads_as_none():
+    legacy = {
+        "id": "old1",
+        "workspace_dir": "/tmp/chud-ws/old1",
+        "status": SessionStatus.DONE.value,
+        "initial_prompt": "legacy",
+        "attached_repos": {},
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "last_activity_at": datetime.now(timezone.utc).isoformat(),
+        "pending_question": None,
+        "error": None,
+        # no "approved_plan" key
+    }
+    s = SessionState.from_dict(legacy)
+    assert s.approved_plan is None

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from chud.types import SessionState
-from chud.worktree import WorktreeError, WorktreeManager, is_git_repo
+from chud.worktree import WorktreeError, WorktreeManager, _slugify, is_git_repo
 
 
 def _init_repo(path: Path) -> None:
@@ -35,7 +35,7 @@ def test_attach_repo_creates_worktree(tmp_path: Path):
     repo = tmp_path / "myrepo"
     _init_repo(repo)
     workspace = tmp_path / "ws"
-    session = SessionState(id="sess1", workspace_dir=workspace)
+    session = SessionState(id="sess1", workspace_dir=workspace, initial_prompt="add foo")
     mgr = WorktreeManager(session)
 
     wt = mgr.attach_repo(repo)
@@ -43,13 +43,15 @@ def test_attach_repo_creates_worktree(tmp_path: Path):
     assert wt.worktree_path == workspace / "myrepo"
     assert wt.worktree_path.exists()
     assert (wt.worktree_path / "README").read_text() == "hi"
-    assert wt.branch == "chud/sess1"
+    assert wt.branch == "chud/add-foo-sess1"
 
 
 def test_attach_repo_idempotent(tmp_path: Path):
     repo = tmp_path / "myrepo"
     _init_repo(repo)
-    session = SessionState(id="sess1", workspace_dir=tmp_path / "ws")
+    session = SessionState(
+        id="sess1", workspace_dir=tmp_path / "ws", initial_prompt="add foo"
+    )
     mgr = WorktreeManager(session)
 
     wt1 = mgr.attach_repo(repo)
@@ -63,7 +65,9 @@ def test_attach_two_repos_same_basename_disambiguated(tmp_path: Path):
     b = tmp_path / "org-b" / "api"
     _init_repo(a)
     _init_repo(b)
-    session = SessionState(id="sess1", workspace_dir=tmp_path / "ws")
+    session = SessionState(
+        id="sess1", workspace_dir=tmp_path / "ws", initial_prompt="add foo"
+    )
     mgr = WorktreeManager(session)
 
     wt_a = mgr.attach_repo(a)
@@ -75,10 +79,39 @@ def test_attach_two_repos_same_basename_disambiguated(tmp_path: Path):
     assert wt_b.worktree_path.exists()
 
 
+def test_attach_repo_branch_falls_back_when_prompt_empty(tmp_path: Path):
+    """Empty prompt → branch uses the ``session`` literal as the slug."""
+    repo = tmp_path / "myrepo"
+    _init_repo(repo)
+    session = SessionState(id="sess1", workspace_dir=tmp_path / "ws", initial_prompt="")
+    mgr = WorktreeManager(session)
+
+    wt = mgr.attach_repo(repo)
+
+    assert wt.branch == "chud/session-sess1"
+
+
+def test_attach_repo_branch_handles_unicode_and_punctuation(tmp_path: Path):
+    repo = tmp_path / "myrepo"
+    _init_repo(repo)
+    session = SessionState(
+        id="sess1",
+        workspace_dir=tmp_path / "ws",
+        initial_prompt="Fix bug: 🚀 in API!",
+    )
+    mgr = WorktreeManager(session)
+
+    wt = mgr.attach_repo(repo)
+
+    assert wt.branch == "chud/fix-bug-in-api-sess1"
+
+
 def test_detach_repo_removes_worktree(tmp_path: Path):
     repo = tmp_path / "myrepo"
     _init_repo(repo)
-    session = SessionState(id="sess1", workspace_dir=tmp_path / "ws")
+    session = SessionState(
+        id="sess1", workspace_dir=tmp_path / "ws", initial_prompt="add foo"
+    )
     mgr = WorktreeManager(session)
     wt = mgr.attach_repo(repo)
     assert wt.worktree_path.exists()
@@ -91,7 +124,9 @@ def test_detach_repo_removes_worktree(tmp_path: Path):
 def test_detach_repo_with_dirty_worktree_requires_force(tmp_path: Path):
     repo = tmp_path / "myrepo"
     _init_repo(repo)
-    session = SessionState(id="sess1", workspace_dir=tmp_path / "ws")
+    session = SessionState(
+        id="sess1", workspace_dir=tmp_path / "ws", initial_prompt="add foo"
+    )
     mgr = WorktreeManager(session)
     wt = mgr.attach_repo(repo)
     (wt.worktree_path / "dirty.txt").write_text("uncommitted")
@@ -101,3 +136,28 @@ def test_detach_repo_with_dirty_worktree_requires_force(tmp_path: Path):
 
     mgr.detach_repo(str(repo), force=True)
     assert not wt.worktree_path.exists()
+
+
+def test_slugify_basic():
+    assert _slugify("Add auth feature") == "add-auth-feature"
+
+
+def test_slugify_strips_punctuation_and_unicode():
+    assert _slugify("Fix bug: 🚀 in API!") == "fix-bug-in-api"
+
+
+def test_slugify_returns_empty_for_emoji_only():
+    assert _slugify("🚀🚀🚀") == ""
+
+
+def test_slugify_only_uses_first_line():
+    assert _slugify("first line\nsecond line should be ignored") == "first-line"
+
+
+def test_slugify_truncates_at_hyphen_boundary():
+    out = _slugify("one two three four five six seven eight nine ten eleven twelve")
+    # max_len default is 40; result should not exceed it and should not end on a partial word.
+    assert len(out) <= 40
+    assert not out.endswith("-")
+    # Should end on a complete word boundary, not mid-word.
+    assert all(part for part in out.split("-"))


### PR DESCRIPTION
The user wants a single line `TODO - cleanup` appended to the end of the project README. This is a trivial one-line addition — likely a placeholder reminder for future cleanup work on the README's content.

---
*Draft PR opened by chud session `f78aa04a`.*
