### PR TITLE
fix: auto-commit agent edits and silently discard empty chud branches

### DIFF
--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -275,10 +275,6 @@ class ChudApp(App[None]):
                 f"[bold red]! PR failed:[/bold red] {repo or '(session)'}: {err}"
             )
         elif event.kind == EventKind.WORKTREE_DISCARDED:
-            # Silent on purpose: a worktree the agent never touched isn't a
-            # failure, just absence of work. Drop a muted transcript line so
-            # the discard is auditable, but no notify() — this is the whole
-            # reason the discard path exists (vs the old PR_FAILED toast).
             branch = event.payload.get("branch", "")
             repo = event.payload.get("repo", "")
             view = self.query_one(SessionView)

--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -274,6 +274,19 @@ class ChudApp(App[None]):
             view.transcript.write(
                 f"[bold red]! PR failed:[/bold red] {repo or '(session)'}: {err}"
             )
+        elif event.kind == EventKind.WORKTREE_DISCARDED:
+            # Silent on purpose: a worktree the agent never touched isn't a
+            # failure, just absence of work. Drop a muted transcript line so
+            # the discard is auditable, but no notify() — this is the whole
+            # reason the discard path exists (vs the old PR_FAILED toast).
+            branch = event.payload.get("branch", "")
+            repo = event.payload.get("repo", "")
+            view = self.query_one(SessionView)
+            view.transcript.write(
+                f"[dim]· discarded empty branch {branch}"
+                + (f" ({repo})" if repo else "")
+                + "[/dim]"
+            )
 
     # ------------------------------------------------------------------ prompt queue
 

--- a/src/chud/manager.py
+++ b/src/chud/manager.py
@@ -31,12 +31,7 @@ class SessionManager:
         self._subscribers: list[asyncio.Queue[Event]] = []
         self._notify_enabled: bool = True
         self._tui_focused: bool = True
-        # Sessions for which we've already fired DONE-side-effects, so re-emitted
-        # STATUS_CHANGED(DONE) events (e.g. after a notification) don't re-trigger.
         self._done_handled: set[str] = set()
-        # Strong refs to in-flight DONE side-effect tasks (PR publish, then
-        # optional cleanup-broadcast) keyed by session id so kill_session can
-        # cancel a session's task in O(1).
         self._pr_tasks: dict[str, asyncio.Task[None]] = {}
 
     # ------------------------------------------------------------------ subscribe
@@ -128,9 +123,6 @@ class SessionManager:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
-        # Cancel any in-flight DONE side-effect (PR publish + queued cleanup
-        # broadcast) before we tear down the worktree, otherwise rmtree races
-        # with git push.
         if done_task is not None and not done_task.done():
             done_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -209,9 +201,6 @@ class SessionManager:
         task.add_done_callback(lambda _t, s=sid: self._pr_tasks.pop(s, None))
 
     async def _finish_done(self, state: SessionState, request_cleanup: bool) -> None:
-        # PR publish must complete before cleanup is offered, otherwise the
-        # cleanup modal can race with the still-running git push and the user
-        # ends up with neither a worktree nor a PR.
         await self._publish_prs(state)
         if request_cleanup:
             await self._broadcast(
@@ -232,17 +221,13 @@ class SessionManager:
             )
             return
         wt_mgr = self.worktrees.get(state.id)
-        any_discarded = False
+        any_discarded_branches = False
         for r in results:
             if r.discarded:
-                # Branch is genuinely empty (clean worktree, no commits ahead
-                # of base). Drop the worktree + branch ref silently — no
-                # PR_FAILED toast — so unused multi-repo attachments and
-                # plan-only sessions don't spam the UI.
                 if wt_mgr is not None and r.repo_label:
                     try:
                         wt_mgr.discard_empty_branch(r.repo_label)
-                        any_discarded = True
+                        any_discarded_branches = True
                     except Exception:
                         log.exception(
                             "discard_empty_branch failed for %s in session %s",
@@ -280,9 +265,7 @@ class SessionManager:
                         },
                     )
                 )
-        # discard_empty_branch mutates state.attached_repos — persist so the
-        # on-disk session record reflects the now-detached worktrees.
-        if any_discarded:
+        if any_discarded_branches:
             self._persist()
 
     # ------------------------------------------------------------------ persistence

--- a/src/chud/manager.py
+++ b/src/chud/manager.py
@@ -231,8 +231,32 @@ class SessionManager:
                 )
             )
             return
+        wt_mgr = self.worktrees.get(state.id)
+        any_discarded = False
         for r in results:
-            if r.error is None and r.url:
+            if r.discarded:
+                # Branch is genuinely empty (clean worktree, no commits ahead
+                # of base). Drop the worktree + branch ref silently — no
+                # PR_FAILED toast — so unused multi-repo attachments and
+                # plan-only sessions don't spam the UI.
+                if wt_mgr is not None and r.repo_label:
+                    try:
+                        wt_mgr.discard_empty_branch(r.repo_label)
+                        any_discarded = True
+                    except Exception:
+                        log.exception(
+                            "discard_empty_branch failed for %s in session %s",
+                            r.repo_label,
+                            state.id,
+                        )
+                await self._broadcast(
+                    Event(
+                        session_id=state.id,
+                        kind=EventKind.WORKTREE_DISCARDED,
+                        payload={"repo": r.repo_label, "branch": r.branch},
+                    )
+                )
+            elif r.error is None and r.url:
                 await self._broadcast(
                     Event(
                         session_id=state.id,
@@ -256,6 +280,10 @@ class SessionManager:
                         },
                     )
                 )
+        # discard_empty_branch mutates state.attached_repos — persist so the
+        # on-disk session record reflects the now-detached worktrees.
+        if any_discarded:
+            self._persist()
 
     # ------------------------------------------------------------------ persistence
 

--- a/src/chud/pr.py
+++ b/src/chud/pr.py
@@ -253,10 +253,6 @@ async def publish_draft_prs(state: SessionState) -> list[PRResult]:
 
         base = await _default_branch(origin)
 
-        # Auto-commit any uncommitted edits the agent left behind. This must
-        # happen before the rev-list step, because the commit changes the
-        # rev-list answer — and the whole point is that an agent who edited
-        # files but didn't commit shouldn't look like an "abandoned" branch.
         if await _is_dirty(worktree):
             ok, err = await _auto_commit(worktree, title, body)
             if not ok:
@@ -283,9 +279,6 @@ async def publish_draft_prs(state: SessionState) -> list[PRResult]:
             )
             continue
         if count.strip() == "0":
-            # We just confirmed clean (no dirty edits) AND no commits ahead
-            # of base — this branch is genuinely abandoned. Mark it for
-            # silent cleanup rather than emitting a noisy PR_FAILED toast.
             results.append(
                 PRResult(repo_label=label, branch=branch, discarded=True)
             )

--- a/src/chud/pr.py
+++ b/src/chud/pr.py
@@ -42,6 +42,7 @@ class PRResult:
     branch: str
     url: str | None = None
     error: str | None = None
+    discarded: bool = False
 
 
 def _no_prompt_env() -> dict[str, str]:
@@ -110,6 +111,47 @@ async def _default_branch(repo_path: Path) -> str:
     if rc == 0 and out:
         return out
     return "main"
+
+
+async def _is_dirty(worktree: Path) -> bool:
+    """Return True iff ``worktree`` has any tracked changes or untracked files.
+
+    Uses ``git status --porcelain``, which prints one line per modified or
+    untracked path and nothing at all on a clean tree. A non-zero git exit
+    is treated as "not dirty" so the caller falls through to the existing
+    rev-list step, where the real failure surfaces with a useful message.
+    """
+    rc, out, _ = await _run(["git", "status", "--porcelain"], cwd=worktree)
+    if rc != 0:
+        return False
+    return bool(out.strip())
+
+
+async def _auto_commit(
+    worktree: Path, title: str, body: str
+) -> tuple[bool, str]:
+    """Stage and commit every change in ``worktree`` under one chud commit.
+
+    The Claude SDK in ``acceptEdits`` mode edits files but never commits, so
+    a session can finish with the agent's work sitting uncommitted. Without
+    this helper, ``publish_draft_prs`` would see ``0`` commits ahead of base
+    and discard the worktree as "abandoned" — losing the agent's work.
+
+    Returns ``(ok, err_text)``. On failure, ``err_text`` carries the git
+    stderr (e.g. "Please tell me who you are" when ``user.email`` is unset,
+    or a pre-commit hook's rejection). Author identity is deferred to the
+    user's local git config — fabricating a chud bot identity would silently
+    make commits the user can't push under their own credentials.
+    """
+    rc, _, err = await _run(["git", "add", "-A"], cwd=worktree)
+    if rc != 0:
+        return False, err or "git add failed"
+    rc, _, err = await _run(
+        ["git", "commit", "-m", title, "-m", body], cwd=worktree
+    )
+    if rc != 0:
+        return False, err or "git commit failed"
+    return True, ""
 
 
 # Match a top-level "# heading" line (single hash, not ## or more). DOTALL is
@@ -211,6 +253,22 @@ async def publish_draft_prs(state: SessionState) -> list[PRResult]:
 
         base = await _default_branch(origin)
 
+        # Auto-commit any uncommitted edits the agent left behind. This must
+        # happen before the rev-list step, because the commit changes the
+        # rev-list answer — and the whole point is that an agent who edited
+        # files but didn't commit shouldn't look like an "abandoned" branch.
+        if await _is_dirty(worktree):
+            ok, err = await _auto_commit(worktree, title, body)
+            if not ok:
+                results.append(
+                    PRResult(
+                        repo_label=label,
+                        branch=branch,
+                        error=f"auto-commit failed: {err}",
+                    )
+                )
+                continue
+
         rc, count, err = await _run(
             ["git", "rev-list", "--count", f"origin/{base}..HEAD"],
             cwd=worktree,
@@ -225,12 +283,11 @@ async def publish_draft_prs(state: SessionState) -> list[PRResult]:
             )
             continue
         if count.strip() == "0":
+            # We just confirmed clean (no dirty edits) AND no commits ahead
+            # of base — this branch is genuinely abandoned. Mark it for
+            # silent cleanup rather than emitting a noisy PR_FAILED toast.
             results.append(
-                PRResult(
-                    repo_label=label,
-                    branch=branch,
-                    error=f"no commits on {branch} ahead of origin/{base}",
-                )
+                PRResult(repo_label=label, branch=branch, discarded=True)
             )
             continue
 

--- a/src/chud/types.py
+++ b/src/chud/types.py
@@ -117,6 +117,7 @@ class EventKind(str, Enum):
     CLEANUP_REQUESTED = "cleanup_requested"
     PR_PUBLISHED = "pr_published"
     PR_FAILED = "pr_failed"
+    WORKTREE_DISCARDED = "worktree_discarded"
 
 
 @dataclass

--- a/src/chud/worktree.py
+++ b/src/chud/worktree.py
@@ -85,7 +85,6 @@ class WorktreeManager:
         if repo_key in self.session.attached_repos:
             return self.session.attached_repos[repo_key]
 
-        # disambiguate dir name if another repo with same basename is already attached
         basename = toplevel.name
         wt_dir_name = basename
         i = 2
@@ -98,8 +97,6 @@ class WorktreeManager:
         slug = _slugify(self.session.initial_prompt) or "session"
         branch = f"chud/{slug}-{self.session.id}"
 
-        # if branch already exists in target repo (rare; same session attaching a repo
-        # we've previously detached and re-attached), reuse it
         branch_exists = (
             subprocess.run(
                 ["git", "-C", str(toplevel), "rev-parse", "--verify", branch],
@@ -159,9 +156,6 @@ class WorktreeManager:
             return
         repo_path = wt.repo_path
         branch = wt.branch
-        # Force-detach: the branch is checked out by this worktree, so a
-        # plain `git branch -D` would refuse. detach_repo also pops the
-        # entry from attached_repos.
         self.detach_repo(repo_key, force=True)
         result = subprocess.run(
             ["git", "-C", str(repo_path), "branch", "-D", branch],

--- a/src/chud/worktree.py
+++ b/src/chud/worktree.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 import re
 import shutil
 import subprocess
 from pathlib import Path
 
 from chud.types import SessionState, Worktree
+
+log = logging.getLogger(__name__)
 
 
 class WorktreeError(RuntimeError):
@@ -137,6 +140,40 @@ class WorktreeManager:
             )
 
         del self.session.attached_repos[repo_key]
+
+    def discard_empty_branch(self, repo_key: str) -> None:
+        """Drop a chud branch that never received a commit.
+
+        For worktrees where the agent did no work (or where a session was
+        cancelled), the ``chud/<slug>-<sid>`` branch ref accumulates in the
+        origin repo with no commits behind it. ``cleanup_workspace`` removes
+        the worktree but leaves the branch ref dangling, so call this when
+        you know the branch is empty: it force-detaches the worktree (so
+        ``git branch -D`` won't complain that it's checked out), then deletes
+        the branch ref. Best-effort on the branch deletion — anything other
+        than a "not found" failure is logged but swallowed so a stuck branch
+        ref doesn't block session cleanup.
+        """
+        wt = self.session.attached_repos.get(repo_key)
+        if wt is None:
+            return
+        repo_path = wt.repo_path
+        branch = wt.branch
+        # Force-detach: the branch is checked out by this worktree, so a
+        # plain `git branch -D` would refuse. detach_repo also pops the
+        # entry from attached_repos.
+        self.detach_repo(repo_key, force=True)
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "branch", "-D", branch],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            if "not found" not in stderr.lower():
+                log.warning(
+                    "git branch -D %s failed in %s: %s", branch, repo_path, stderr
+                )
 
     def cleanup_workspace(self) -> None:
         """Remove all attached worktrees and the workspace dir. Destructive."""

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -153,8 +153,8 @@ async def test_publish_draft_prs_when_gh_missing(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_publish_draft_prs_skips_when_no_commits(monkeypatch):
-    """rev-list reports 0 commits → skip push, return descriptive error."""
+async def test_publish_draft_prs_discards_clean_empty_branch(monkeypatch):
+    """Clean worktree + 0 commits → discarded=True, no error, no push/PR."""
     monkeypatch.setattr(pr_mod.shutil, "which", lambda _: "/usr/bin/gh")
 
     calls: list[list[str]] = []
@@ -163,6 +163,8 @@ async def test_publish_draft_prs_skips_when_no_commits(monkeypatch):
         calls.append(cmd)
         if cmd[:2] == ["git", "symbolic-ref"]:
             return 0, "origin/main", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, "", ""  # clean
         if cmd[:3] == ["git", "rev-list", "--count"]:
             return 0, "0", ""
         # Anything else means we accidentally tried to push or open a PR.
@@ -173,11 +175,118 @@ async def test_publish_draft_prs_skips_when_no_commits(monkeypatch):
     results = await pr_mod.publish_draft_prs(_state_with_one_repo())
     assert len(results) == 1
     assert results[0].url is None
-    assert results[0].error is not None
-    assert "no commits" in results[0].error
-    # Verify we never attempted a push or PR creation.
+    assert results[0].error is None
+    assert results[0].discarded is True
+    # No commit, no push, no gh.
+    assert not any(c[:2] == ["git", "commit"] for c in calls)
     assert not any(c[:2] == ["git", "push"] for c in calls)
     assert not any(c[:1] == ["gh"] for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_publish_draft_prs_auto_commits_dirty_worktree(monkeypatch):
+    """Dirty worktree → auto-commit fires, then push + PR open succeed."""
+    monkeypatch.setattr(pr_mod.shutil, "which", lambda _: "/usr/bin/gh")
+
+    calls: list[list[str]] = []
+
+    async def fake_run(cmd, cwd=None):
+        calls.append(cmd)
+        if cmd[:2] == ["git", "symbolic-ref"]:
+            return 0, "origin/main", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, " M src/foo.py\n?? src/new.py", ""  # dirty
+        if cmd[:3] == ["git", "add", "-A"]:
+            return 0, "", ""
+        if cmd[:2] == ["git", "commit"]:
+            return 0, "", ""
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            # After auto-commit there's exactly one new commit ahead of base.
+            return 0, "1", ""
+        if cmd[:3] == ["git", "push", "-u"]:
+            return 0, "", ""
+        if cmd[:1] == ["gh"]:
+            return 0, "https://github.com/x/y/pull/7", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(pr_mod, "_run", fake_run)
+
+    results = await pr_mod.publish_draft_prs(_state_with_one_repo())
+    assert len(results) == 1
+    assert results[0].error is None
+    assert results[0].url == "https://github.com/x/y/pull/7"
+    assert results[0].discarded is False
+    # Auto-commit ran, with a non-empty title as the commit subject.
+    add_calls = [c for c in calls if c[:3] == ["git", "add", "-A"]]
+    commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
+    assert len(add_calls) == 1
+    assert len(commit_calls) == 1
+    # Subject derived from prompt fallback ("add a foo"); not empty.
+    assert "-m" in commit_calls[0]
+    msg_idx = commit_calls[0].index("-m") + 1
+    assert commit_calls[0][msg_idx] == "add a foo"
+
+
+@pytest.mark.asyncio
+async def test_publish_draft_prs_auto_commit_uses_plan_title(monkeypatch):
+    """When an approved plan exists, its H1 becomes the commit subject."""
+    monkeypatch.setattr(pr_mod.shutil, "which", lambda _: "/usr/bin/gh")
+
+    captured_subject: dict[str, str] = {}
+
+    async def fake_run(cmd, cwd=None):
+        if cmd[:2] == ["git", "symbolic-ref"]:
+            return 0, "origin/main", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, " M f", ""
+        if cmd[:3] == ["git", "add", "-A"]:
+            return 0, "", ""
+        if cmd[:2] == ["git", "commit"]:
+            captured_subject["v"] = cmd[cmd.index("-m") + 1]
+            return 0, "", ""
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return 0, "1", ""
+        if cmd[:3] == ["git", "push", "-u"]:
+            return 0, "", ""
+        if cmd[:1] == ["gh"]:
+            return 0, "https://github.com/x/y/pull/8", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(pr_mod, "_run", fake_run)
+
+    state = _state_with_one_repo(
+        approved_plan="# Fix the parser\n\n## Context\n\nIt was wrong.\n"
+    )
+    results = await pr_mod.publish_draft_prs(state)
+    assert results[0].error is None
+    assert captured_subject["v"] == "Fix the parser"
+
+
+@pytest.mark.asyncio
+async def test_publish_draft_prs_auto_commit_failure_surfaces_as_error(monkeypatch):
+    """A pre-commit hook (or any commit failure) becomes a PR_FAILED error."""
+    monkeypatch.setattr(pr_mod.shutil, "which", lambda _: "/usr/bin/gh")
+
+    async def fake_run(cmd, cwd=None):
+        if cmd[:2] == ["git", "symbolic-ref"]:
+            return 0, "origin/main", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, " M f", ""
+        if cmd[:3] == ["git", "add", "-A"]:
+            return 0, "", ""
+        if cmd[:2] == ["git", "commit"]:
+            return 1, "", "pre-commit hook rejected: lint failed"
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(pr_mod, "_run", fake_run)
+
+    results = await pr_mod.publish_draft_prs(_state_with_one_repo())
+    assert len(results) == 1
+    assert results[0].url is None
+    assert results[0].discarded is False
+    assert results[0].error is not None
+    assert results[0].error.startswith("auto-commit failed:")
+    assert "pre-commit hook rejected" in results[0].error
 
 
 @pytest.mark.asyncio
@@ -187,6 +296,8 @@ async def test_publish_draft_prs_happy_path(monkeypatch):
     async def fake_run(cmd, cwd=None):
         if cmd[:2] == ["git", "symbolic-ref"]:
             return 0, "origin/main", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, "", ""  # clean — agent already committed
         if cmd[:3] == ["git", "rev-list", "--count"]:
             return 0, "3", ""
         if cmd[:3] == ["git", "push", "-u"]:
@@ -211,6 +322,8 @@ async def test_publish_draft_prs_reports_push_failure(monkeypatch):
     async def fake_run(cmd, cwd=None):
         if cmd[:2] == ["git", "symbolic-ref"]:
             return 0, "origin/main", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, "", ""
         if cmd[:3] == ["git", "rev-list", "--count"]:
             return 0, "1", ""
         if cmd[:3] == ["git", "push", "-u"]:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -138,6 +138,51 @@ def test_detach_repo_with_dirty_worktree_requires_force(tmp_path: Path):
     assert not wt.worktree_path.exists()
 
 
+def test_discard_empty_branch_removes_worktree_and_branch_ref(tmp_path: Path):
+    """Empty branch → worktree gone + ``chud/...`` branch ref deleted in origin."""
+    repo = tmp_path / "myrepo"
+    _init_repo(repo)
+    session = SessionState(
+        id="sess1", workspace_dir=tmp_path / "ws", initial_prompt="add foo"
+    )
+    mgr = WorktreeManager(session)
+    wt = mgr.attach_repo(repo)
+    assert wt.worktree_path.exists()
+    # Sanity: the branch was just created in the origin.
+    list_before = subprocess.run(
+        ["git", "-C", str(repo), "branch", "--list", wt.branch],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert wt.branch in list_before.stdout
+
+    mgr.discard_empty_branch(str(repo))
+
+    # (a) worktree path gone
+    assert not wt.worktree_path.exists()
+    # (b) branch ref gone from origin
+    list_after = subprocess.run(
+        ["git", "-C", str(repo), "branch", "--list", wt.branch],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert wt.branch not in list_after.stdout
+    # (c) attached_repos entry removed
+    assert str(repo) not in session.attached_repos
+
+
+def test_discard_empty_branch_no_op_for_unknown_repo(tmp_path: Path):
+    """Discarding a repo that isn't attached is a silent no-op."""
+    session = SessionState(
+        id="sess1", workspace_dir=tmp_path / "ws", initial_prompt="add foo"
+    )
+    mgr = WorktreeManager(session)
+    # Should not raise.
+    mgr.discard_empty_branch("/does/not/exist")
+
+
 def test_slugify_basic():
     assert _slugify("Add auth feature") == "add-auth-feature"
 


### PR DESCRIPTION
Sessions that ended with uncommitted edits (the common single-repo case) or with attached repos the agent never touched were producing noisy "PR failed: no commits on chud/..." toasts and accumulating empty branch refs. publish_draft_prs now auto-commits any dirty worktree using the plan title/body as the commit message, and routes genuinely-empty branches through a new WORKTREE_DISCARDED event that force-detaches the worktree and deletes the branch ref without surfacing a failure.