### PR TITLE
feat: route AskUserQuestion tool calls to a chud user prompt

### DIFF
--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -450,8 +450,6 @@ class ChudApp(App[None]):
                 if isinstance(result, str) and result:
                     await sess.answer_question(result)
                 else:
-                    # Cancel / dismissed: still resolve the future so the agent
-                    # doesn't hang waiting on a Deny that never arrives.
                     await sess.answer_question(
                         "(user dismissed the question without answering)"
                     )

--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -18,12 +18,13 @@ from chud.widgets.attach_repo_modal import AttachRepoModal
 from chud.widgets.cleanup_confirmation_modal import CleanupConfirmationModal
 from chud.widgets.new_session_modal import NewSessionModal, NewSessionResult
 from chud.widgets.plan_modal import PlanApprovalModal
+from chud.widgets.question_modal import QuestionModal
 from chud.widgets.session_list import SessionListView, SessionRow
 from chud.widgets.session_view import SessionView
 
 log = logging.getLogger(__name__)
 
-PromptKind = Literal["plan", "cleanup", "input"]
+PromptKind = Literal["plan", "cleanup", "input", "question"]
 
 
 @dataclass
@@ -69,6 +70,7 @@ class ChudApp(App[None]):
         self._selected_session_id: str | None = None
         self._open_plan_modals: set[str] = set()
         self._open_cleanup_modals: set[str] = set()
+        self._open_question_modals: set[str] = set()
         # FIFO queue of blocking user-input requests from agents. The first
         # request is shown until resolved; later requests wait their turn so a
         # newly-arrived modal can't cover one the user hasn't answered yet.
@@ -243,6 +245,14 @@ class ChudApp(App[None]):
                     payload={"plan": event.payload.get("plan", "")},
                 )
             )
+        elif event.kind == EventKind.QUESTION_ASKED:
+            self._enqueue_prompt(
+                PromptRequest(
+                    session_id=event.session_id,
+                    kind="question",
+                    payload={"input": event.payload.get("input", {})},
+                )
+            )
         elif event.kind == EventKind.CLEANUP_REQUESTED:
             self._enqueue_prompt(
                 PromptRequest(session_id=event.session_id, kind="cleanup")
@@ -315,6 +325,8 @@ class ChudApp(App[None]):
                 self._show_cleanup_modal(req)
             elif req.kind == "input":
                 self._show_input_focus(req)
+            elif req.kind == "question":
+                self._show_question_modal(req)
             return
 
     def _resolve_active_prompt(self, req: PromptRequest) -> None:
@@ -415,6 +427,36 @@ class ChudApp(App[None]):
                 self._drop_session_prompts(session_id)
             finally:
                 self._open_cleanup_modals.discard(session_id)
+                self._resolve_active_prompt(req)
+
+        self.run_worker(show_modal(), exclusive=False)
+
+    def _show_question_modal(self, req: PromptRequest) -> None:
+        session_id = req.session_id
+        question_input = req.payload.get("input", {}) or {}
+        if session_id in self._open_question_modals:
+            self._resolve_active_prompt(req)
+            return
+        self._open_question_modals.add(session_id)
+
+        async def show_modal() -> None:
+            try:
+                result = await self.push_screen_wait(
+                    QuestionModal(session_id=session_id, question_input=question_input)
+                )
+                sess = self.manager.sessions.get(session_id)
+                if sess is None:
+                    return
+                if isinstance(result, str) and result:
+                    await sess.answer_question(result)
+                else:
+                    # Cancel / dismissed: still resolve the future so the agent
+                    # doesn't hang waiting on a Deny that never arrives.
+                    await sess.answer_question(
+                        "(user dismissed the question without answering)"
+                    )
+            finally:
+                self._open_question_modals.discard(session_id)
                 self._resolve_active_prompt(req)
 
         self.run_worker(show_modal(), exclusive=False)

--- a/src/chud/session.py
+++ b/src/chud/session.py
@@ -58,6 +58,10 @@ class AgentSession:
             None
         )
         self._pending_plan_text: str | None = None
+        self._question_decision: (
+            asyncio.Future[PermissionResultAllow | PermissionResultDeny] | None
+        ) = None
+        self._pending_question_input: dict[str, Any] | None = None
 
     # ------------------------------------------------------------------ lifecycle
 
@@ -105,6 +109,13 @@ class AgentSession:
             )
         self._plan_decision = None
         self._pending_plan_text = None
+
+        if self._question_decision is not None and not self._question_decision.done():
+            self._question_decision.set_result(
+                PermissionResultDeny(message="Session stopped.")
+            )
+        self._question_decision = None
+        self._pending_question_input = None
 
         if self._client is not None:
             with contextlib.suppress(Exception):
@@ -157,6 +168,23 @@ class AgentSession:
         self._pending_plan_text = None
         await self._set_status(SessionStatus.PLANNING)
 
+    async def answer_question(self, answer_text: str) -> None:
+        """Resolve a pending AskUserQuestion tool call with the user's answer.
+
+        The answer is delivered to the model via PermissionResultDeny.message —
+        the same SDK channel reject_plan() uses to ferry free-text feedback into
+        the agent. From the model's POV this reads as the tool's response.
+        """
+        if self._question_decision is None or self._question_decision.done():
+            log.warning(
+                "answer_question called with no pending decision (session %s)", self.state.id
+            )
+            return
+        self._question_decision.set_result(PermissionResultDeny(message=answer_text))
+        self._question_decision = None
+        self._pending_question_input = None
+        await self._set_status(SessionStatus.EXECUTING)
+
     # ------------------------------------------------------------------ SDK callbacks
 
     async def _on_tool_request(
@@ -173,6 +201,19 @@ class AgentSession:
             await self._set_status(SessionStatus.AWAITING_PLAN_APPROVAL)
             await self._emit(EventKind.PLAN_PROPOSED, {"plan": plan_text})
             return await self._plan_decision
+
+        if tool_name == "AskUserQuestion":
+            # AskUserQuestion is a Claude Code harness builtin — the SDK has no
+            # implementation, so allowing it through hangs the agent. Intercept
+            # it like ExitPlanMode: stash the input, surface a modal via the
+            # event queue, and wait for answer_question() to resolve the future
+            # with a Deny whose .message carries the user's selection back to
+            # the model.
+            self._pending_question_input = dict(tool_input)
+            self._question_decision = asyncio.get_event_loop().create_future()
+            await self._set_status(SessionStatus.AWAITING_USER)
+            await self._emit(EventKind.QUESTION_ASKED, {"input": dict(tool_input)})
+            return await self._question_decision
 
         # Default: allow. Future iterations may add a deny-list or interactive gating
         # for non-plan tools (e.g., destructive Bash). v1 trusts acceptEdits.

--- a/src/chud/types.py
+++ b/src/chud/types.py
@@ -111,6 +111,7 @@ class EventKind(str, Enum):
     TRANSCRIPT_APPENDED = "transcript_appended"
     PLAN_PROPOSED = "plan_proposed"
     NEEDS_USER_INPUT = "needs_user_input"
+    QUESTION_ASKED = "question_asked"
     REPO_ATTACHED = "repo_attached"
     UNKNOWN_MESSAGE = "unknown_message"
     ERROR = "error"

--- a/src/chud/widgets/question_modal.py
+++ b/src/chud/widgets/question_modal.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Input, RadioButton, RadioSet, Static
+
+
+class QuestionModal(ModalScreen[str | None]):
+    """Render an AskUserQuestion tool call and collect the user's answer.
+
+    The agent's tool input shape (defensively parsed):
+
+        {"questions": [
+            {"question": "...", "header": "...", "multiSelect": false,
+             "options": [{"label": "...", "description": "..."}]}
+        ]}
+
+    Returns:
+        - str on submit: a formatted summary of selections, e.g.
+          ``"Q1: A | Q2: B, C"`` (with "; other: <text>" appended if the user
+          typed a free-text addition).
+        - None on cancel: the caller should treat this as the user declining
+          to answer so the agent's pending tool call can still be unblocked.
+    """
+
+    DEFAULT_CSS = """
+    QuestionModal {
+        align: center middle;
+    }
+    QuestionModal > Vertical {
+        width: 90%;
+        max-width: 120;
+        height: 80%;
+        background: $surface;
+        border: round $accent;
+        padding: 1 2;
+    }
+    QuestionModal #question-title {
+        height: 1;
+        color: $accent;
+    }
+    QuestionModal VerticalScroll {
+        height: 1fr;
+        margin-top: 1;
+        margin-bottom: 1;
+    }
+    QuestionModal .question-header {
+        color: $accent;
+        margin-top: 1;
+    }
+    QuestionModal .question-text {
+        margin-bottom: 1;
+    }
+    QuestionModal #other-input {
+        height: 3;
+        margin-top: 1;
+    }
+    QuestionModal Horizontal {
+        height: 3;
+        align: right middle;
+    }
+    QuestionModal Button {
+        margin-left: 2;
+    }
+    """
+
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, session_id: str, question_input: dict[str, Any]) -> None:
+        super().__init__()
+        self.session_id = session_id
+        self.question_input = question_input
+        # Normalize to a list of dicts; tolerate malformed input by falling
+        # back to a single synthetic question whose body is the raw JSON.
+        raw_questions = question_input.get("questions")
+        if isinstance(raw_questions, list) and raw_questions:
+            self.questions: list[dict[str, Any]] = [
+                q if isinstance(q, dict) else {"question": str(q)} for q in raw_questions
+            ]
+        else:
+            self.questions = [
+                {
+                    "question": "(unrecognized AskUserQuestion shape — raw input below)",
+                    "options": [],
+                    "multiSelect": False,
+                    "_raw": json.dumps(question_input, default=str, indent=2),
+                }
+            ]
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static(
+                f"[bold]Question from session {self.session_id[:8]}[/bold]",
+                id="question-title",
+            )
+            with VerticalScroll():
+                for idx, q in enumerate(self.questions):
+                    header = str(q.get("header") or "").strip()
+                    if header:
+                        yield Static(f"[bold]{header}[/bold]", classes="question-header")
+                    yield Static(
+                        str(q.get("question") or "(no question text)"),
+                        classes="question-text",
+                    )
+                    raw = q.get("_raw")
+                    if raw:
+                        yield Static(f"[dim]{raw}[/dim]")
+                    options = q.get("options") or []
+                    multi = bool(q.get("multiSelect"))
+                    if not options:
+                        # No options — user can only respond via the free-text
+                        # "Other" input below; nothing to render here.
+                        continue
+                    if multi:
+                        for opt_idx, opt in enumerate(options):
+                            label = _format_option(opt)
+                            yield Checkbox(label, id=f"q{idx}-opt{opt_idx}")
+                    else:
+                        with RadioSet(id=f"q{idx}-radio"):
+                            for opt_idx, opt in enumerate(options):
+                                label = _format_option(opt)
+                                yield RadioButton(label, id=f"q{idx}-opt{opt_idx}")
+            yield Input(
+                placeholder="Other / free-text answer (optional)…",
+                id="other-input",
+            )
+            with Horizontal():
+                cancel_btn = Button("Cancel (Esc)", id="cancel", variant="error")
+                cancel_btn.can_focus = False
+                yield cancel_btn
+                submit_btn = Button("Submit", id="submit", variant="success")
+                submit_btn.can_focus = False
+                yield submit_btn
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "submit":
+            self._submit()
+        elif event.button.id == "cancel":
+            self.dismiss(None)
+
+    @on(Input.Submitted, "#other-input")
+    def _on_other_submitted(self, event: Input.Submitted) -> None:
+        self._submit()
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _submit(self) -> None:
+        parts: list[str] = []
+        for idx, q in enumerate(self.questions):
+            options = q.get("options") or []
+            if not options:
+                continue
+            multi = bool(q.get("multiSelect"))
+            chosen_labels: list[str] = []
+            if multi:
+                for opt_idx, opt in enumerate(options):
+                    try:
+                        cb = self.query_one(f"#q{idx}-opt{opt_idx}", Checkbox)
+                    except Exception:
+                        continue
+                    if cb.value:
+                        chosen_labels.append(_option_label(opt))
+            else:
+                try:
+                    rs = self.query_one(f"#q{idx}-radio", RadioSet)
+                except Exception:
+                    rs = None
+                if rs is not None and rs.pressed_index >= 0:
+                    chosen = options[rs.pressed_index]
+                    chosen_labels.append(_option_label(chosen))
+            label = q.get("header") or q.get("question") or f"Q{idx + 1}"
+            short = str(label).strip().splitlines()[0][:60]
+            answer = ", ".join(chosen_labels) if chosen_labels else "(no selection)"
+            parts.append(f"{short}: {answer}")
+
+        try:
+            other = self.query_one("#other-input", Input).value.strip()
+        except Exception:
+            other = ""
+        summary = " | ".join(parts) if parts else ""
+        if other:
+            summary = f"{summary}; other: {other}" if summary else other
+        if not summary:
+            summary = "(no selection)"
+        self.dismiss(summary)
+
+
+def _option_label(opt: Any) -> str:
+    if isinstance(opt, dict):
+        return str(opt.get("label") or opt.get("value") or opt)
+    return str(opt)
+
+
+def _format_option(opt: Any) -> str:
+    if isinstance(opt, dict):
+        label = str(opt.get("label") or opt.get("value") or opt)
+        desc = str(opt.get("description") or "").strip()
+        if desc:
+            return f"{label} [dim]— {desc}[/dim]"
+        return label
+    return str(opt)

--- a/src/chud/widgets/question_modal.py
+++ b/src/chud/widgets/question_modal.py
@@ -12,20 +12,6 @@ from textual.widgets import Button, Checkbox, Input, RadioButton, RadioSet, Stat
 
 class QuestionModal(ModalScreen[str | None]):
     """Render an AskUserQuestion tool call and collect the user's answer.
-
-    The agent's tool input shape (defensively parsed):
-
-        {"questions": [
-            {"question": "...", "header": "...", "multiSelect": false,
-             "options": [{"label": "...", "description": "..."}]}
-        ]}
-
-    Returns:
-        - str on submit: a formatted summary of selections, e.g.
-          ``"Q1: A | Q2: B, C"`` (with "; other: <text>" appended if the user
-          typed a free-text addition).
-        - None on cancel: the caller should treat this as the user declining
-          to answer so the agent's pending tool call can still be unblocked.
     """
 
     DEFAULT_CSS = """
@@ -115,8 +101,6 @@ class QuestionModal(ModalScreen[str | None]):
                     options = q.get("options") or []
                     multi = bool(q.get("multiSelect"))
                     if not options:
-                        # No options — user can only respond via the free-text
-                        # "Other" input below; nothing to render here.
                         continue
                     if multi:
                         for opt_idx, opt in enumerate(options):

--- a/src/chud/widgets/session_view.py
+++ b/src/chud/widgets/session_view.py
@@ -93,6 +93,16 @@ class SessionView(Vertical):
             self.transcript.write(
                 "[bold magenta]── Plan proposed (modal will open) ──[/bold magenta]"
             )
+        elif kind == EventKind.QUESTION_ASKED:
+            qs = (p.get("input") or {}).get("questions") or []
+            first = ""
+            if qs and isinstance(qs[0], dict):
+                first = str(qs[0].get("question") or qs[0].get("header") or "")
+            preview = escape(first[:120]) if first else ""
+            line = "[bold yellow]? agent asked a question[/bold yellow]"
+            if preview:
+                line = f"{line}: {preview}"
+            self.transcript.write(line)
         elif kind == EventKind.NEEDS_USER_INPUT:
             msg = p.get("message") or p.get("reason", "agent waiting")
             self.transcript.write(f"[bold red]? agent needs input: {escape(str(msg))}[/bold red]")

--- a/tests/test_session_question.py
+++ b/tests/test_session_question.py
@@ -1,0 +1,106 @@
+"""Tests for AgentSession's AskUserQuestion interception flow.
+
+When the inner agent calls the AskUserQuestion harness builtin, the SDK has no
+implementation to fulfill it — so chud intercepts the permission callback,
+emits a QUESTION_ASKED event for the UI, and waits for ``answer_question()``
+to deliver the user's response back to the model via PermissionResultDeny.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from claude_agent_sdk.types import PermissionResultDeny
+
+from chud.session import AgentSession
+from chud.types import EventKind, SessionState, SessionStatus
+
+
+def _make_session(tmp_path: Path) -> AgentSession:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    state = SessionState(id="t-question", workspace_dir=workspace)
+    state.status = SessionStatus.EXECUTING
+    return AgentSession(state)
+
+
+async def _drain(events: asyncio.Queue, kind: EventKind, timeout: float = 1.0) -> dict:
+    """Pull events until we hit the requested kind, or fail on timeout."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            raise AssertionError(f"timed out waiting for {kind}")
+        ev = await asyncio.wait_for(events.get(), timeout=remaining)
+        if ev.kind == kind:
+            return ev.payload
+
+
+async def test_ask_user_question_intercept_and_answer(tmp_path):
+    sess = _make_session(tmp_path)
+    tool_input = {
+        "questions": [
+            {
+                "question": "Pick one",
+                "options": [{"label": "A"}, {"label": "B"}],
+                "multiSelect": False,
+            }
+        ]
+    }
+
+    # Kick off the permission callback. It will block on the future until we
+    # call answer_question(); race a task that resolves it.
+    request_task = asyncio.create_task(
+        sess._on_tool_request("AskUserQuestion", tool_input, context=None)  # type: ignore[arg-type]
+    )
+
+    payload = await _drain(sess.events, EventKind.QUESTION_ASKED)
+    assert payload["input"] == tool_input
+    assert sess.state.status == SessionStatus.AWAITING_USER
+    assert sess._question_decision is not None
+    assert not sess._question_decision.done()
+
+    await sess.answer_question("Pick one: A")
+
+    result = await asyncio.wait_for(request_task, timeout=1.0)
+    assert isinstance(result, PermissionResultDeny)
+    assert result.message == "Pick one: A"
+    assert sess.state.status == SessionStatus.EXECUTING
+    assert sess._question_decision is None
+    assert sess._pending_question_input is None
+
+
+async def test_answer_question_with_no_pending_decision_is_noop(tmp_path):
+    sess = _make_session(tmp_path)
+    # No future scheduled — should warn and return without raising.
+    await sess.answer_question("nothing pending")
+    assert sess._question_decision is None
+
+
+async def test_stop_resolves_in_flight_question_decision(tmp_path):
+    """Tearing down a session mid-question must not strand the SDK round-trip."""
+    sess = _make_session(tmp_path)
+    sess._question_decision = asyncio.get_event_loop().create_future()
+    sess._pending_question_input = {"questions": []}
+
+    await sess.stop()
+
+    assert sess._question_decision is None
+    assert sess._pending_question_input is None
+
+
+async def test_dismiss_path_still_unblocks_agent(tmp_path):
+    """The app falls back to a sentinel string on cancel; verify the future
+    still resolves and the model gets a non-empty message back."""
+    sess = _make_session(tmp_path)
+    request_task = asyncio.create_task(
+        sess._on_tool_request("AskUserQuestion", {"questions": []}, context=None)  # type: ignore[arg-type]
+    )
+    await _drain(sess.events, EventKind.QUESTION_ASKED)
+
+    await sess.answer_question("(user dismissed the question without answering)")
+
+    result = await asyncio.wait_for(request_task, timeout=1.0)
+    assert isinstance(result, PermissionResultDeny)
+    assert "dismissed" in result.message


### PR DESCRIPTION
The inner agent's AskUserQuestion calls were silently dropped because the SDK has no implementation for that harness builtin and the permission callback returned Allow. Intercept the tool like ExitPlanMode, surface a modal, and feed the user's answer back via PermissionResultDeny.message.