### PR TITLE
fix: Add F2 submit binding to QuestionModal

### DIFF
--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -19,13 +19,14 @@ from chud.widgets.attach_repo_modal import AttachRepoModal
 from chud.widgets.cleanup_confirmation_modal import CleanupConfirmationModal
 from chud.widgets.new_session_modal import NewSessionModal, NewSessionResult
 from chud.widgets.plan_modal import PlanApprovalModal
+from chud.widgets.pr_review_modal import PRReviewModal, PRReviewResult
 from chud.widgets.question_modal import QuestionModal
 from chud.widgets.session_list import SessionListView, SessionRow
 from chud.widgets.session_view import SessionView
 
 log = logging.getLogger(__name__)
 
-PromptKind = Literal["plan", "cleanup", "input", "question"]
+PromptKind = Literal["plan", "pr_review", "cleanup", "input", "question"]
 
 
 @dataclass
@@ -71,6 +72,7 @@ class ChudApp(App[None]):
         self._selected_session_id: str | None = None
         self._open_plan_modals: set[str] = set()
         self._open_cleanup_modals: set[str] = set()
+        self._open_pr_review_modals: set[str] = set()
         self._open_question_modals: set[str] = set()
         # FIFO queue of blocking user-input requests from agents. The first
         # request is shown until resolved; later requests wait their turn so a
@@ -255,6 +257,18 @@ class ChudApp(App[None]):
                     payload={"plan": event.payload.get("plan", "")},
                 )
             )
+        elif event.kind == EventKind.PR_REVIEW_REQUESTED:
+            self._enqueue_prompt(
+                PromptRequest(
+                    session_id=event.session_id,
+                    kind="pr_review",
+                    payload={
+                        "title": event.payload.get("title", ""),
+                        "body": event.payload.get("body", ""),
+                        "repos": list(event.payload.get("repos", []) or []),
+                    },
+                )
+            )
         elif event.kind == EventKind.QUESTION_ASKED:
             self._enqueue_prompt(
                 PromptRequest(
@@ -340,6 +354,8 @@ class ChudApp(App[None]):
             self._prompt_active = req
             if req.kind == "plan":
                 self._show_plan_modal(req)
+            elif req.kind == "pr_review":
+                self._show_pr_review_modal(req)
             elif req.kind == "cleanup":
                 self._show_cleanup_modal(req)
             elif req.kind == "input":
@@ -446,6 +462,55 @@ class ChudApp(App[None]):
                 self._drop_session_prompts(session_id)
             finally:
                 self._open_cleanup_modals.discard(session_id)
+                self._resolve_active_prompt(req)
+
+        self.run_worker(show_modal(), exclusive=False)
+
+    def _show_pr_review_modal(self, req: PromptRequest) -> None:
+        session_id = req.session_id
+        if session_id in self._open_pr_review_modals:
+            self._resolve_active_prompt(req)
+            return
+        if self.manager.sessions.get(session_id) is None:
+            self._resolve_active_prompt(req)
+            return
+        self._open_pr_review_modals.add(session_id)
+        title = str(req.payload.get("title", "") or "")
+        body = str(req.payload.get("body", "") or "")
+        repos = list(req.payload.get("repos", []) or [])
+
+        async def show_modal() -> None:
+            try:
+                result: PRReviewResult | None = await self.push_screen_wait(
+                    PRReviewModal(
+                        session_id=session_id,
+                        title=title,
+                        body=body,
+                        repos=repos,
+                    )
+                )
+                # ``None`` (e.g. unexpected dismissal) is treated as a reject so
+                # the post-PR cleanup prompt — if enabled — still progresses.
+                if result is None:
+                    accepted = False
+                    edited_title: str | None = None
+                    edited_body: str | None = None
+                else:
+                    accepted = result.accepted
+                    edited_title = result.title
+                    edited_body = result.body
+                try:
+                    await self.manager.submit_pr_review(
+                        session_id,
+                        accepted=accepted,
+                        title=edited_title,
+                        body=edited_body,
+                    )
+                except Exception as e:
+                    log.exception("submit_pr_review failed for %s", session_id)
+                    self.notify(f"PR review failed: {e}", severity="error")
+            finally:
+                self._open_pr_review_modals.discard(session_id)
                 self._resolve_active_prompt(req)
 
         self.run_worker(show_modal(), exclusive=False)

--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -553,11 +553,8 @@ class ChudApp(App[None]):
             self._resolve_active_prompt(req)
             return
         self._select_session(req.session_id)
-        try:
+        with contextlib.suppress(Exception):
             self.query_one(SessionView).input.focus()
-        except Exception:
-            # Focusing is best-effort; the prompt is still considered "shown".
-            pass
 
 
 def main() -> int:

--- a/src/chud/manager.py
+++ b/src/chud/manager.py
@@ -194,22 +194,69 @@ class SessionManager:
                 Event(session_id=sid, kind=EventKind.CLEANUP_REQUESTED, payload={})
             )
             return
-        task = asyncio.create_task(
-            self._finish_done(sess.state, do_cleanup), name=f"chud-done-{sid}"
-        )
-        self._pr_tasks[sid] = task
-        task.add_done_callback(lambda _t, s=sid: self._pr_tasks.pop(s, None))
-
-    async def _finish_done(self, state: SessionState, request_cleanup: bool) -> None:
-        await self._publish_prs(state)
-        if request_cleanup:
-            await self._broadcast(
-                Event(session_id=state.id, kind=EventKind.CLEANUP_REQUESTED, payload={})
+        # Defer the actual publish until the user accepts the proposed
+        # title/body via the PR-review modal. The app responds via
+        # ``submit_pr_review`` which runs the publish-then-cleanup chain.
+        await self._broadcast(
+            Event(
+                session_id=sid,
+                kind=EventKind.PR_REVIEW_REQUESTED,
+                payload={
+                    "title": pr_mod.pick_title(sess.state),
+                    "body": pr_mod.pick_body(sess.state),
+                    "repos": list(sess.state.attached_repos.keys()),
+                },
             )
+        )
 
-    async def _publish_prs(self, state: SessionState) -> None:
+    async def submit_pr_review(
+        self,
+        session_id: str,
+        accepted: bool,
+        title: str | None = None,
+        body: str | None = None,
+    ) -> None:
+        """User response to a ``PR_REVIEW_REQUESTED`` prompt.
+
+        On accept, publish the PR(s) with the (possibly edited) title/body.
+        On reject, skip the publish. Either way, if the session opted into
+        self-cleanup, broadcast ``CLEANUP_REQUESTED`` *after* the publish has
+        finished, preserving the same ordering guarantee that protected the
+        old auto-publish path.
+        """
+        sess = self.sessions.get(session_id)
+        if sess is None:
+            return
+        opts = sess.state.options or {}
+        do_cleanup = bool(opts.get(OPT_SELF_CLEANUP))
+
+        async def runner(state: SessionState = sess.state) -> None:
+            if accepted:
+                await self._publish_prs(state, title=title, body=body)
+            if do_cleanup:
+                await self._broadcast(
+                    Event(
+                        session_id=state.id,
+                        kind=EventKind.CLEANUP_REQUESTED,
+                        payload={},
+                    )
+                )
+
+        # Reuse the same task-tracking slot so kill_session cancels an
+        # in-flight publish-then-cleanup chain in O(1), exactly like the
+        # legacy ``_finish_done`` task did.
+        task = asyncio.create_task(runner(), name=f"chud-pr-review-{session_id}")
+        self._pr_tasks[session_id] = task
+        task.add_done_callback(lambda _t, s=session_id: self._pr_tasks.pop(s, None))
+
+    async def _publish_prs(
+        self,
+        state: SessionState,
+        title: str | None = None,
+        body: str | None = None,
+    ) -> None:
         try:
-            results = await pr_mod.publish_draft_prs(state)
+            results = await pr_mod.publish_draft_prs(state, title=title, body=body)
         except Exception as e:
             log.exception("publish_draft_prs crashed for session %s", state.id)
             await self._broadcast(

--- a/src/chud/pr.py
+++ b/src/chud/pr.py
@@ -212,7 +212,7 @@ def _body_from_prompt(session_id: str, prompt: str) -> str:
     )
 
 
-def _pick_title(state: SessionState) -> str:
+def pick_title(state: SessionState) -> str:
     """Prefer the approved plan's H1 heading; fall back to the prompt."""
     if state.approved_plan:
         plan_title = _extract_plan_title(state.approved_plan)
@@ -221,7 +221,7 @@ def _pick_title(state: SessionState) -> str:
     return _title_from_prompt(state.initial_prompt)
 
 
-def _pick_body(state: SessionState) -> str:
+def pick_body(state: SessionState) -> str:
     """Prefer the plan's ``## Context`` section as the body lead, with a
     small footer pointing back to the chud session id. Fall back to the
     prompt-only body when no plan is available.
@@ -233,8 +233,24 @@ def _pick_body(state: SessionState) -> str:
     return _body_from_prompt(state.id, state.initial_prompt)
 
 
-async def publish_draft_prs(state: SessionState) -> list[PRResult]:
+# Backwards-compatible aliases for any callers (and tests) still using the
+# original underscore-prefixed names. Safe to remove once no internal user
+# remains.
+_pick_title = pick_title
+_pick_body = pick_body
+
+
+async def publish_draft_prs(
+    state: SessionState,
+    title: str | None = None,
+    body: str | None = None,
+) -> list[PRResult]:
     """For each attached worktree: push the chud branch and open a draft PR.
+
+    ``title`` / ``body`` override the plan-derived defaults when supplied
+    (e.g. after the user edits them in the PR-review modal). Both are applied
+    verbatim to every attached repo's PR; per-repo overrides are not modeled
+    yet.
 
     Returns one ``PRResult`` per attached repo. If ``gh`` isn't on PATH, returns
     a single failure result tagged with an empty repo label.
@@ -242,8 +258,8 @@ async def publish_draft_prs(state: SessionState) -> list[PRResult]:
     if shutil.which("gh") is None:
         return [PRResult(repo_label="", branch="", error="gh CLI not installed")]
 
-    title = _pick_title(state)
-    body = _pick_body(state)
+    title = title if title is not None else pick_title(state)
+    body = body if body is not None else pick_body(state)
     results: list[PRResult] = []
 
     for label, wt in state.attached_repos.items():

--- a/src/chud/types.py
+++ b/src/chud/types.py
@@ -116,6 +116,7 @@ class EventKind(str, Enum):
     UNKNOWN_MESSAGE = "unknown_message"
     ERROR = "error"
     CLEANUP_REQUESTED = "cleanup_requested"
+    PR_REVIEW_REQUESTED = "pr_review_requested"
     PR_PUBLISHED = "pr_published"
     PR_FAILED = "pr_failed"
     WORKTREE_DISCARDED = "worktree_discarded"

--- a/src/chud/widgets/pr_review_modal.py
+++ b/src/chud/widgets/pr_review_modal.py
@@ -1,0 +1,152 @@
+"""Modal that lets the user review (and edit) a draft PR before it's opened.
+
+Surfaced after a session reaches DONE when both
+``OPT_MAKE_DRAFT_PR`` is enabled and a ``PR_REVIEW_REQUESTED`` event arrives.
+The modal returns a ``PRReviewResult`` describing whether the user accepted
+the PR (and the possibly-edited title/body) or rejected it.
+
+If both PR-review and self-cleanup options are on, this modal always runs
+*before* the cleanup confirmation — see ``SessionManager.submit_pr_review``
+for the ordering guarantee.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, Static, TextArea
+
+
+@dataclass
+class PRReviewResult:
+    accepted: bool
+    title: str
+    body: str
+
+
+class PRReviewModal(ModalScreen[PRReviewResult | None]):
+    """Show the proposed draft-PR title/body and gate publishing on approval.
+
+    Returns:
+        - ``PRReviewResult(accepted=True, title=..., body=...)`` on accept.
+        - ``PRReviewResult(accepted=False, title=..., body=...)`` on reject.
+        - ``None`` only if the modal is dismissed without a button (treated by
+          callers as a reject so the post-PR cleanup prompt can still progress).
+    """
+
+    DEFAULT_CSS = """
+    PRReviewModal {
+        align: center middle;
+    }
+    PRReviewModal > Vertical {
+        width: 90%;
+        max-width: 120;
+        height: 80%;
+        background: $surface;
+        border: round $accent;
+        padding: 1 2;
+    }
+    PRReviewModal #pr-title-static {
+        height: 1;
+        color: $accent;
+    }
+    PRReviewModal Label {
+        height: 1;
+        color: $text-muted;
+        margin-top: 1;
+    }
+    PRReviewModal #repos {
+        height: auto;
+        max-height: 5;
+        margin-bottom: 1;
+        color: $text-muted;
+    }
+    PRReviewModal #title-input {
+        margin-bottom: 1;
+    }
+    PRReviewModal TextArea {
+        height: 1fr;
+        min-height: 6;
+        margin-bottom: 1;
+    }
+    PRReviewModal Horizontal#buttons {
+        height: 3;
+        align: right middle;
+    }
+    PRReviewModal Button {
+        margin-left: 2;
+    }
+    """
+
+    BINDINGS = [
+        ("escape", "reject", "Reject"),
+    ]
+
+    def __init__(
+        self,
+        session_id: str,
+        title: str,
+        body: str,
+        repos: Iterable[str] = (),
+    ) -> None:
+        super().__init__()
+        self.session_id = session_id
+        self._initial_title = title
+        self._initial_body = body
+        self._repos = list(repos)
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static(
+                f"[bold]Open draft PR(s) for session {self.session_id[:8]}?[/bold]",
+                id="pr-title-static",
+            )
+            with VerticalScroll(id="repos"):
+                if self._repos:
+                    for label in self._repos:
+                        yield Static(f"  • [yellow]{label}[/yellow]")
+                else:
+                    yield Static("  [dim](no attached repos)[/dim]")
+            yield Label("Title")
+            yield Input(value=self._initial_title, id="title-input")
+            yield Label("Body")
+            yield TextArea(self._initial_body, id="body-input")
+            with Horizontal(id="buttons"):
+                # Same trick as PlanApprovalModal: keep buttons mouse-clickable
+                # but never let them grab keyboard focus, so editing the
+                # Input/TextArea above stays unobstructed.
+                reject_btn = Button("Reject (skip PR)", id="reject", variant="error")
+                reject_btn.can_focus = False
+                yield reject_btn
+                accept_btn = Button("Accept (open PR)", id="accept", variant="success")
+                accept_btn.can_focus = False
+                yield accept_btn
+
+    def on_mount(self) -> None:
+        with contextlib.suppress(Exception):
+            self.query_one("#title-input", Input).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "accept":
+            self._dismiss(accepted=True)
+        elif event.button.id == "reject":
+            self._dismiss(accepted=False)
+
+    def action_reject(self) -> None:
+        self._dismiss(accepted=False)
+
+    def _dismiss(self, *, accepted: bool) -> None:
+        try:
+            title = self.query_one("#title-input", Input).value
+        except Exception:
+            title = self._initial_title
+        try:
+            body = self.query_one("#body-input", TextArea).text
+        except Exception:
+            body = self._initial_body
+        self.dismiss(PRReviewResult(accepted=accepted, title=title, body=body))

--- a/src/chud/widgets/pr_review_modal.py
+++ b/src/chud/widgets/pr_review_modal.py
@@ -85,6 +85,7 @@ class PRReviewModal(ModalScreen[PRReviewResult | None]):
 
     BINDINGS = [
         ("escape", "reject", "Reject"),
+        ("f2", "accept", "Accept"),
     ]
 
     def __init__(
@@ -120,10 +121,10 @@ class PRReviewModal(ModalScreen[PRReviewResult | None]):
                 # Same trick as PlanApprovalModal: keep buttons mouse-clickable
                 # but never let them grab keyboard focus, so editing the
                 # Input/TextArea above stays unobstructed.
-                reject_btn = Button("Reject (skip PR)", id="reject", variant="error")
+                reject_btn = Button("Reject — skip PR (Esc)", id="reject", variant="error")
                 reject_btn.can_focus = False
                 yield reject_btn
-                accept_btn = Button("Accept (open PR)", id="accept", variant="success")
+                accept_btn = Button("Accept — open PR (F2)", id="accept", variant="success")
                 accept_btn.can_focus = False
                 yield accept_btn
 
@@ -139,6 +140,9 @@ class PRReviewModal(ModalScreen[PRReviewResult | None]):
 
     def action_reject(self) -> None:
         self._dismiss(accepted=False)
+
+    def action_accept(self) -> None:
+        self._dismiss(accepted=True)
 
     def _dismiss(self, *, accepted: bool) -> None:
         try:

--- a/src/chud/widgets/question_modal.py
+++ b/src/chud/widgets/question_modal.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from textual import on
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Input, RadioButton, RadioSet, Static
@@ -56,7 +57,8 @@ class QuestionModal(ModalScreen[str | None]):
     """
 
     BINDINGS = [
-        ("escape", "cancel", "Cancel"),
+        Binding("escape", "cancel", "Cancel"),
+        Binding("f2", "submit", "Submit", priority=True),
     ]
 
     def __init__(self, session_id: str, question_input: dict[str, Any]) -> None:
@@ -119,7 +121,7 @@ class QuestionModal(ModalScreen[str | None]):
                 cancel_btn = Button("Cancel (Esc)", id="cancel", variant="error")
                 cancel_btn.can_focus = False
                 yield cancel_btn
-                submit_btn = Button("Submit", id="submit", variant="success")
+                submit_btn = Button("Submit (F2)", id="submit", variant="success")
                 submit_btn.can_focus = False
                 yield submit_btn
 
@@ -135,6 +137,9 @@ class QuestionModal(ModalScreen[str | None]):
 
     def action_cancel(self) -> None:
         self.dismiss(None)
+
+    def action_submit(self) -> None:
+        self._submit()
 
     def _submit(self) -> None:
         parts: list[str] = []

--- a/tests/test_manager_done_hooks.py
+++ b/tests/test_manager_done_hooks.py
@@ -72,7 +72,11 @@ async def test_done_without_options_emits_no_extra_events(tmp_path, monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_done_with_make_draft_pr_invokes_publisher(tmp_path, monkeypatch):
+async def test_done_with_make_draft_pr_requests_review_not_publish(
+    tmp_path, monkeypatch
+):
+    """DONE with the draft-PR option must broadcast PR_REVIEW_REQUESTED and
+    NOT publish until ``submit_pr_review(accepted=True)`` is invoked."""
     mgr = SessionManager()
     sess = _make_session({OPT_MAKE_DRAFT_PR: True, OPT_SELF_CLEANUP: False}, tmp_path)
     mgr.sessions[sess.state.id] = sess
@@ -80,20 +84,111 @@ async def test_done_with_make_draft_pr_invokes_publisher(tmp_path, monkeypatch):
 
     calls: list[str] = []
 
-    async def fake_publish(state):
+    async def fake_publish(state, title=None, body=None):
         calls.append(state.id)
         return []
 
     monkeypatch.setattr(pr_mod, "publish_draft_prs", fake_publish)
 
+    queue = mgr.subscribe()
     await mgr._handle_event(_done_event(sess.state.id), sess)
 
-    # _on_session_done schedules an asyncio task; await pending tasks.
-    pending = list(mgr._pr_tasks.values())
-    for task in pending:
+    # No pending PR task yet — the manager waits for submit_pr_review.
+    for task in list(mgr._pr_tasks.values()):
+        await task
+    assert calls == []
+
+    kinds: list[EventKind] = []
+    while not queue.empty():
+        kinds.append(queue.get_nowait().kind)
+    assert EventKind.PR_REVIEW_REQUESTED in kinds
+    assert EventKind.PR_PUBLISHED not in kinds
+
+
+@pytest.mark.asyncio
+async def test_submit_pr_review_accept_publishes(tmp_path, monkeypatch):
+    mgr = SessionManager()
+    sess = _make_session({OPT_MAKE_DRAFT_PR: True, OPT_SELF_CLEANUP: False}, tmp_path)
+    mgr.sessions[sess.state.id] = sess
+    monkeypatch.setattr(mgr, "_persist", lambda: None)
+
+    seen: list[tuple[str, str | None, str | None]] = []
+
+    async def fake_publish(state, title=None, body=None):
+        seen.append((state.id, title, body))
+        return [PRResult(repo_label="r", branch="b", url="https://e/pr/1")]
+
+    monkeypatch.setattr(pr_mod, "publish_draft_prs", fake_publish)
+
+    queue = mgr.subscribe()
+    await mgr.submit_pr_review(
+        sess.state.id, accepted=True, title="edited title", body="edited body"
+    )
+    for task in list(mgr._pr_tasks.values()):
         await task
 
-    assert calls == [sess.state.id]
+    assert seen == [(sess.state.id, "edited title", "edited body")]
+    kinds: list[EventKind] = []
+    while not queue.empty():
+        kinds.append(queue.get_nowait().kind)
+    assert EventKind.PR_PUBLISHED in kinds
+    assert EventKind.CLEANUP_REQUESTED not in kinds
+
+
+@pytest.mark.asyncio
+async def test_submit_pr_review_reject_skips_publish(tmp_path, monkeypatch):
+    mgr = SessionManager()
+    sess = _make_session({OPT_MAKE_DRAFT_PR: True, OPT_SELF_CLEANUP: False}, tmp_path)
+    mgr.sessions[sess.state.id] = sess
+    monkeypatch.setattr(mgr, "_persist", lambda: None)
+
+    calls: list[str] = []
+
+    async def fake_publish(state, title=None, body=None):
+        calls.append(state.id)
+        return []
+
+    monkeypatch.setattr(pr_mod, "publish_draft_prs", fake_publish)
+
+    queue = mgr.subscribe()
+    await mgr.submit_pr_review(sess.state.id, accepted=False)
+    for task in list(mgr._pr_tasks.values()):
+        await task
+
+    assert calls == []
+    kinds: list[EventKind] = []
+    while not queue.empty():
+        kinds.append(queue.get_nowait().kind)
+    assert EventKind.PR_PUBLISHED not in kinds
+    assert EventKind.CLEANUP_REQUESTED not in kinds
+
+
+@pytest.mark.asyncio
+async def test_submit_pr_review_reject_with_cleanup_emits_cleanup(
+    tmp_path, monkeypatch
+):
+    """Rejecting the PR must still trigger the cleanup prompt when the
+    self-cleanup option is enabled — the user may have rejected the PR
+    *because* they want to wipe the workspace."""
+    mgr = SessionManager()
+    sess = _make_session({OPT_MAKE_DRAFT_PR: True, OPT_SELF_CLEANUP: True}, tmp_path)
+    mgr.sessions[sess.state.id] = sess
+    monkeypatch.setattr(mgr, "_persist", lambda: None)
+
+    async def fake_publish(state, title=None, body=None):
+        raise AssertionError("publish must not run on reject")
+
+    monkeypatch.setattr(pr_mod, "publish_draft_prs", fake_publish)
+
+    queue = mgr.subscribe()
+    await mgr.submit_pr_review(sess.state.id, accepted=False)
+    for task in list(mgr._pr_tasks.values()):
+        await task
+
+    kinds: list[EventKind] = []
+    while not queue.empty():
+        kinds.append(queue.get_nowait().kind)
+    assert kinds.count(EventKind.CLEANUP_REQUESTED) == 1
 
 
 @pytest.mark.asyncio
@@ -172,11 +267,12 @@ async def test_kill_session_default_does_not_cleanup(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_done_with_pr_and_cleanup_orders_events(tmp_path, monkeypatch):
+async def test_accepted_pr_and_cleanup_orders_events(tmp_path, monkeypatch):
     """CLEANUP_REQUESTED must be broadcast only after publish_draft_prs returns.
 
     Locks the bug where cleanup raced PR publish, wiping the worktree before
-    git push could finish.
+    git push could finish. Now the user explicitly accepts via
+    ``submit_pr_review`` before publish runs.
     """
     mgr = SessionManager()
     sess = _make_session(
@@ -185,7 +281,7 @@ async def test_done_with_pr_and_cleanup_orders_events(tmp_path, monkeypatch):
     mgr.sessions[sess.state.id] = sess
     monkeypatch.setattr(mgr, "_persist", lambda: None)
 
-    async def fake_publish(state):
+    async def fake_publish(state, title=None, body=None):
         for _ in range(3):
             await asyncio.sleep(0)
         return [PRResult(repo_label="r", branch="b", url="https://example/pr/1")]
@@ -193,8 +289,15 @@ async def test_done_with_pr_and_cleanup_orders_events(tmp_path, monkeypatch):
     monkeypatch.setattr(pr_mod, "publish_draft_prs", fake_publish)
 
     queue = mgr.subscribe()
-    await mgr._handle_event(_done_event(sess.state.id), sess)
 
+    # DONE first surfaces the review request.
+    await mgr._handle_event(_done_event(sess.state.id), sess)
+    # Drain the review-request event so we only inspect the publish→cleanup
+    # ordering produced by submit_pr_review.
+    while not queue.empty():
+        queue.get_nowait()
+
+    await mgr.submit_pr_review(sess.state.id, accepted=True)
     for task in list(mgr._pr_tasks.values()):
         await task
 
@@ -210,8 +313,9 @@ async def test_done_with_pr_and_cleanup_orders_events(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_done_with_pr_failure_still_emits_cleanup(tmp_path, monkeypatch):
-    """If PR publish raises, cleanup is still offered (after PR_FAILED)."""
+async def test_accepted_pr_failure_still_emits_cleanup(tmp_path, monkeypatch):
+    """If PR publish raises after the user accepts, cleanup is still offered
+    (after PR_FAILED)."""
     mgr = SessionManager()
     sess = _make_session(
         {OPT_MAKE_DRAFT_PR: True, OPT_SELF_CLEANUP: True}, tmp_path
@@ -219,14 +323,17 @@ async def test_done_with_pr_failure_still_emits_cleanup(tmp_path, monkeypatch):
     mgr.sessions[sess.state.id] = sess
     monkeypatch.setattr(mgr, "_persist", lambda: None)
 
-    async def boom(state):
+    async def boom(state, title=None, body=None):
         raise RuntimeError("publish exploded")
 
     monkeypatch.setattr(pr_mod, "publish_draft_prs", boom)
 
     queue = mgr.subscribe()
     await mgr._handle_event(_done_event(sess.state.id), sess)
+    while not queue.empty():
+        queue.get_nowait()
 
+    await mgr.submit_pr_review(sess.state.id, accepted=True)
     for task in list(mgr._pr_tasks.values()):
         await task
 

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -339,6 +339,43 @@ async def test_publish_draft_prs_reports_push_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_publish_draft_prs_uses_override_title_and_body(monkeypatch):
+    """Caller-supplied title/body must reach `gh pr create` verbatim."""
+    monkeypatch.setattr(pr_mod.shutil, "which", lambda _: "/usr/bin/gh")
+
+    captured: list[list[str]] = []
+
+    async def fake_run(cmd, cwd=None):
+        captured.append(cmd)
+        if cmd[:2] == ["git", "symbolic-ref"]:
+            return 0, "origin/main", ""
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return 0, "1", ""
+        if cmd[:3] == ["git", "push", "-u"]:
+            return 0, "", ""
+        if cmd[:1] == ["gh"]:
+            return 0, "https://github.com/x/y/pull/7", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(pr_mod, "_run", fake_run)
+
+    results = await pr_mod.publish_draft_prs(
+        _state_with_one_repo(),
+        title="user-edited title",
+        body="user-edited body",
+    )
+    assert len(results) == 1 and results[0].url == "https://github.com/x/y/pull/7"
+
+    gh_calls = [c for c in captured if c[:1] == ["gh"]]
+    assert len(gh_calls) == 1
+    cmd = gh_calls[0]
+    assert "user-edited title" in cmd
+    assert "user-edited body" in cmd
+    # And the H1/Context defaults should NOT have been used.
+    assert "add a foo" not in " ".join(cmd)
+
+
+@pytest.mark.asyncio
 async def test_default_branch_falls_back_to_main(monkeypatch):
     async def fake_run(cmd, cwd=None):
         # Both lookups fail / return nothing useful → fallback.

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -349,6 +349,8 @@ async def test_publish_draft_prs_uses_override_title_and_body(monkeypatch):
         captured.append(cmd)
         if cmd[:2] == ["git", "symbolic-ref"]:
             return 0, "origin/main", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, "", ""
         if cmd[:3] == ["git", "rev-list", "--count"]:
             return 0, "1", ""
         if cmd[:3] == ["git", "push", "-u"]:

--- a/tests/test_prompt_queue.py
+++ b/tests/test_prompt_queue.py
@@ -165,7 +165,7 @@ async def test_plan_then_input_for_different_session_queues_correctly(tmp_path):
     async with app.run_test() as pilot:
         await pilot.pause()
         sess_a = _register_session(app, "sess-a", tmp_path)
-        sess_b = _register_session(app, "sess-b", tmp_path)
+        _register_session(app, "sess-b", tmp_path)
 
         # Stub the SDK calls that the plan modal would trigger on approve.
         async def noop_approve():


### PR DESCRIPTION
`QuestionModal` (the modal that handles `AskUserQuestion` tool calls from the agent) is the one modal in chud that does not honor F2 to submit. Other modals (`NewSessionModal`, `PRReviewModal`) bind F2 with `priority=True` so it works even while focus is in an `Input`/`TextArea`. The user expects F2 to behave consistently across every modal — currently, the only ways to submit `QuestionModal` are clicking the Submit button or pressing Enter while focused in the free-text `Input`, both of which are inconsistent with the rest of the app.

---
*Draft PR opened by chud session `02375ffe`.*
