### PR TITLE
feat: Optional GitHub issue picker on the new-session modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ All under `~/.local/share/chud/` (resolved via `platformdirs`):
 - Custom exceptions for failure boundaries (e.g. `WorktreeError`).
 - `contextlib.suppress` for best-effort cleanup paths.
 - Lint/format via `ruff` — line length `100`, target `py310`, rules `E,F,I,UP,B,SIM` (`pyproject.toml`).
+- Avoid verbose comment blocks — prefer self-explanatory code with well-named identifiers. Only comment when the *why* is non-obvious (a hidden constraint, subtle invariant, or workaround).
+- Favor refactoring over patching. When a change exposes duplication, awkward seams, or muddled responsibilities, restructure the code rather than layering more logic on top.
 
 ## Dependencies
 

--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -13,7 +13,9 @@ from textual.app import App, ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import Footer, Header, Input, ListView
 
+from chud import gh as gh_mod
 from chud import state as state_mod
+from chud.gh import Issue
 from chud.manager import SessionManager
 from chud.types import Event, EventKind, SessionStatus
 from chud.widgets.attach_repo_modal import AttachRepoModal
@@ -125,20 +127,50 @@ class ChudApp(App[None]):
     def action_new_session(self) -> None:
         self.run_worker(self._new_session_flow(), exclusive=False)
 
+    async def _fetch_issues_for_modal(self, repo_path: Path) -> list[Issue] | None:
+        """Best-effort issue list for the new-session picker; ``None`` to hide.
+
+        Returns ``None`` when ``gh`` isn't installed *or* when the call
+        succeeded but the repo has no open issues — both collapse to the
+        same hide-the-picker branch in the modal. ``gh.list_issues`` already
+        swallows network/auth/JSON failures internally.
+        """
+        if not gh_mod.is_available():
+            return None
+        try:
+            issues = await gh_mod.list_issues(repo_path)
+        except Exception:
+            log.exception("gh.list_issues raised in %s", repo_path)
+            return None
+        return issues or None
+
     async def _new_session_flow(self) -> None:
+        # Detect the cwd repo and pre-fetch issues *before* showing the modal
+        # so the picker can render immediately. The fetch has its own 5s
+        # timeout in gh.list_issues, so a slow network never delays the modal
+        # by more than that.
+        detected = detect_cwd_repo()
+        issues = await self._fetch_issues_for_modal(detected) if detected is not None else None
+
         self._user_modal_depth += 1
         try:
-            result: NewSessionResult | None = await self.push_screen_wait(NewSessionModal())
+            result: NewSessionResult | None = await self.push_screen_wait(
+                NewSessionModal(issues=issues)
+            )
         finally:
             self._user_modal_depth -= 1
             self._maybe_show_next_prompt()
         if result is None:
             return
-        detected = detect_cwd_repo()
+        if result.issue is not None:
+            log.info("new session linked to issue #%d", result.issue.number)
+            final_prompt = gh_mod.build_issue_prompt(result.issue, result.prompt)
+        else:
+            final_prompt = result.prompt
         launch = None if detected is not None else Path.cwd()
         try:
             sess = await self.manager.create_session(
-                prompt=result.prompt,
+                prompt=final_prompt,
                 repo_path=detected,
                 launch_cwd=launch,
                 options=result.options,

--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -92,6 +92,20 @@ class ChudApp(App[None]):
         # AttachRepo). While > 0, session-driven prompts stay queued so they
         # can't pop over a modal the user is actively typing into.
         self._user_modal_depth: int = 0
+        # Launch-time repo + cached open issues for the new-session modal.
+        # Populated in on_mount() and refreshed in the background so pressing
+        # `n` doesn't pay for a `gh issue list` shell-out each time.
+        # ``_issues_cache`` mirrors ``_fetch_issues_for_modal``'s contract:
+        # ``None`` means "hide picker" (no gh / no repo / first refresh
+        # in-flight / no open issues), non-empty list means ready.
+        # ``_issues_with_pr_cache`` carries the set of issue numbers that
+        # have an open PR linked (closing-keyword or Development-sidebar);
+        # populated by ``gh.list_issue_numbers_with_open_pr`` in the same
+        # background refresh and used to filter the picker.
+        self._launch_repo: Path | None = None
+        self._issues_cache: list[Issue] | None = None
+        self._issues_with_pr_cache: set[int] = set()
+        self._issues_timer: Any = None  # textual.timer.Timer; loose typing.
 
     # ------------------------------------------------------------------ layout
 
@@ -110,8 +124,65 @@ class ChudApp(App[None]):
         self.run_worker(self._event_pump(), exclusive=False, name="event-pump")
         if self._dev_hook is not None:
             self.run_worker(self._dev_hook(self), exclusive=False, name="dev-hook")
+        # Detect launch repo once + start background issue refresh so the
+        # new-session picker is ready when the user presses `n`. Skip when
+        # gh isn't installed (no point polling) or chud was launched outside
+        # any git repo (nothing to fetch).
+        self._launch_repo = detect_cwd_repo()
+        if self._launch_repo is not None and gh_mod.is_available():
+            self.run_worker(self._refresh_issues_cache(), exclusive=False, name="issues-init")
+            # Periodic refresh so a fresh issue created during the session
+            # appears within a couple of minutes. Open-issue lists don't churn
+            # often, so 120s is a generous floor that keeps the cost trivial.
+            self._issues_timer = self.set_interval(120.0, self._schedule_issues_refresh)
+
+    def _schedule_issues_refresh(self) -> None:
+        """Timer callback — schedule a fresh fetch as a background worker."""
+        self.run_worker(self._refresh_issues_cache(), exclusive=False, name="issues-refresh")
+
+    def _active_sessions_by_issue(self) -> dict[int, list[str]]:
+        """Map of GitHub issue number → session ids of *active* chud sessions
+        currently linked to that issue.
+
+        "Active" means status is anything other than DONE/ERRORED — i.e. a
+        chud is still working on it. Used by ``NewSessionModal`` to mark
+        issues in the picker dropdown so the user knows another session is
+        already on it before they spin up a duplicate.
+        """
+        result: dict[int, list[str]] = {}
+        terminal = {SessionStatus.DONE, SessionStatus.ERRORED}
+        for sid, sess in self.manager.sessions.items():
+            issue_num = sess.state.issue_number
+            if issue_num is None or sess.state.status in terminal:
+                continue
+            result.setdefault(issue_num, []).append(sid)
+        return result
+
+    async def _refresh_issues_cache(self) -> None:
+        """Fetch the launch repo's open issues + PR-linked issue numbers and
+        update both caches.
+
+        On any failure (logged inside the gh helpers) we keep the previous
+        cached value rather than blanking the picker — a stale list is
+        better than no list at the moment the user presses `n`.
+        """
+        if self._launch_repo is None:
+            return
+        self._issues_cache = await self._fetch_issues_for_modal(self._launch_repo)
+        # Only fetch the PR-linked set if we actually have issues (otherwise
+        # there's nothing to filter and the second subprocess is wasted).
+        if self._issues_cache:
+            self._issues_with_pr_cache = await gh_mod.list_issue_numbers_with_open_pr(
+                self._launch_repo
+            )
+        else:
+            self._issues_with_pr_cache = set()
 
     async def on_unmount(self) -> None:
+        if self._issues_timer is not None:
+            with contextlib.suppress(Exception):
+                self._issues_timer.stop()
+            self._issues_timer = None
         await self.manager.shutdown()
 
     # ------------------------------------------------------------------ focus
@@ -145,17 +216,28 @@ class ChudApp(App[None]):
         return issues or None
 
     async def _new_session_flow(self) -> None:
-        # Detect the cwd repo and pre-fetch issues *before* showing the modal
-        # so the picker can render immediately. The fetch has its own 5s
-        # timeout in gh.list_issues, so a slow network never delays the modal
-        # by more than that.
+        # Detect the cwd repo synchronously (it's a quick `git rev-parse`).
+        # For the issue picker, consume the background-refreshed cache —
+        # awaiting `gh issue list` here was the source of the `n`-press lag.
+        # If the cache hasn't loaded yet (very first `n` within ~hundreds of
+        # ms of startup, or chud launched outside a repo) the picker is just
+        # hidden for this open and the modal still appears instantly.
         detected = detect_cwd_repo()
-        issues = await self._fetch_issues_for_modal(detected) if detected is not None else None
+        issues = self._issues_cache if detected is not None else None
+        if issues and self._issues_with_pr_cache:
+            # Drop issues that already have an open PR linked to them
+            # (closing-keyword reference or Development-sidebar link) — the
+            # user presumably doesn't want to spawn a duplicate chud on
+            # something already in review, regardless of who or what made
+            # the PR. The set comes from the same background refresh that
+            # populated ``_issues_cache``.
+            issues = [i for i in issues if i.number not in self._issues_with_pr_cache]
+        active_by_issue = self._active_sessions_by_issue() if issues else {}
 
         self._user_modal_depth += 1
         try:
             result: NewSessionResult | None = await self.push_screen_wait(
-                NewSessionModal(issues=issues)
+                NewSessionModal(issues=issues, active_sessions_by_issue=active_by_issue)
             )
         finally:
             self._user_modal_depth -= 1
@@ -163,10 +245,11 @@ class ChudApp(App[None]):
         if result is None:
             return
         if result.issue is not None:
+            # The modal already pre-populated the prompt with the issue's
+            # head + body + "---" separator (see NewSessionModal.on_select_changed),
+            # so result.prompt is already the merged text — no second prepend.
             log.info("new session linked to issue #%d", result.issue.number)
-            final_prompt = gh_mod.build_issue_prompt(result.issue, result.prompt)
-        else:
-            final_prompt = result.prompt
+        final_prompt = result.prompt
         launch = None if detected is not None else Path.cwd()
         try:
             sess = await self.manager.create_session(
@@ -175,6 +258,7 @@ class ChudApp(App[None]):
                 launch_cwd=launch,
                 options=result.options,
                 effort=result.effort,
+                issue_number=result.issue.number if result.issue is not None else None,
             )
         except Exception as e:
             log.exception("create_session failed")
@@ -377,6 +461,15 @@ class ChudApp(App[None]):
             self.notify(f"Draft PR opened ({repo}): {url}")
             view = self.query_one(SessionView)
             view.transcript.write(f"[bold green]+ draft PR:[/bold green] {repo} → {url}")
+            # Refresh the issues + PR-link caches now so the next `n` press
+            # filters out the issue this PR just attached to, instead of
+            # waiting for the 120s background tick. GitHub may need a moment
+            # to register the Development-sidebar link, so this is best-
+            # effort — the periodic refresh will catch any lag.
+            if self._launch_repo is not None:
+                self.run_worker(
+                    self._refresh_issues_cache(), exclusive=False, name="issues-pr-refresh"
+                )
         elif event.kind == EventKind.PR_FAILED:
             err = event.payload.get("error", "")
             repo = event.payload.get("repo", "")

--- a/src/chud/gh.py
+++ b/src/chud/gh.py
@@ -191,6 +191,106 @@ async def list_issues(
     return issues
 
 
+_ISSUES_WITH_OPEN_PR_QUERY = """\
+query($owner: String!, $name: String!, $first: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: $first, states: OPEN) {
+      nodes {
+        closingIssuesReferences(first: 20) {
+          nodes { number }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+async def list_issue_numbers_with_open_pr(
+    repo_path: Path,
+    *,
+    pr_limit: int = 100,
+    timeout: float = _LIST_ISSUES_TIMEOUT_S,
+) -> set[int]:
+    """Return the set of issue numbers that have any open PR linked to them.
+
+    Uses ``gh api graphql`` to read each open PR's ``closingIssuesReferences``
+    — which covers both closing-keyword references in the PR body / commits
+    (``closes #N``) and links added manually through GitHub's Development
+    sidebar. The new-session picker uses the result to hide issues already
+    in review, regardless of who or what made the PR.
+
+    The ``--json`` flag on ``gh issue list`` doesn't expose this field on
+    older gh versions (we hit that on 2.x in the field), so we go straight
+    to GraphQL — which always has it.
+
+    Every failure mode (no auth, owner/name lookup fails, timeout,
+    malformed JSON) collapses to an empty set; the caller treats that as
+    "no filter info" and the picker stays unfiltered rather than empty.
+    """
+    rc, out, err = await _run(
+        ["gh", "repo", "view", "--json", "owner,name"],
+        cwd=repo_path,
+        timeout=timeout,
+    )
+    if rc != 0:
+        log.warning("gh repo view failed (rc=%d) in %s: %s", rc, repo_path, err)
+        return set()
+    try:
+        meta = json.loads(out)
+        owner = str(meta["owner"]["login"])
+        name = str(meta["name"])
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        log.warning("gh repo view returned unexpected JSON in %s: %s", repo_path, e)
+        return set()
+
+    rc, out, err = await _run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={_ISSUES_WITH_OPEN_PR_QUERY}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"first={pr_limit}",
+        ],
+        cwd=repo_path,
+        timeout=timeout,
+    )
+    if rc != 0:
+        log.warning("gh api graphql (PRs) failed (rc=%d) in %s: %s", rc, repo_path, err)
+        return set()
+    try:
+        raw = json.loads(out)
+        nodes = raw["data"]["repository"]["pullRequests"]["nodes"]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        log.warning("gh api graphql (PRs) returned unexpected JSON in %s: %s", repo_path, e)
+        return set()
+    if not isinstance(nodes, list):
+        return set()
+
+    out_set: set[int] = set()
+    for n in nodes:
+        if not isinstance(n, dict):
+            continue
+        closing = n.get("closingIssuesReferences") or {}
+        pr_nodes = closing.get("nodes") if isinstance(closing, dict) else None
+        if not isinstance(pr_nodes, list):
+            continue
+        for ref in pr_nodes:
+            if not isinstance(ref, dict):
+                continue
+            try:
+                out_set.add(int(ref["number"]))
+            except (KeyError, TypeError, ValueError):
+                continue
+    return out_set
+
+
 def build_issue_prompt(issue: Issue, user_prompt: str) -> str:
     """Render the agent's initial prompt with a linked GitHub issue prepended.
 

--- a/src/chud/gh.py
+++ b/src/chud/gh.py
@@ -1,0 +1,221 @@
+"""Thin wrappers around the ``gh`` CLI plus a generic async subprocess runner.
+
+Two responsibilities live here:
+
+1. **GitHub-issue helpers** for the new-session modal: ``Issue``,
+   ``is_available``, ``list_issues``, and the pure ``build_issue_prompt``
+   formatter. These let the TUI offer "link this session to issue #X" without
+   blocking the modal on a slow network — every failure mode collapses to an
+   empty list and the picker hides silently.
+2. **Shared subprocess plumbing** (``_run``, ``_no_prompt_env``,
+   ``_RUN_TIMEOUT_S``) used by both the issue lookups here and the PR-publish
+   flow in ``chud.pr``. Centralizing them avoids two copies of "kill on
+   timeout, hide credential prompts, never block the TUI" logic drifting out
+   of sync.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# A real GitHub push completes in a few seconds; anything past this is a
+# hang, typically a credential prompt that the TUI's raw-mode terminal
+# can't satisfy. Without this guard, ``pr.publish_draft_prs`` parks
+# forever and the post-DONE CLEANUP_REQUESTED broadcast never fires.
+_RUN_TIMEOUT_S = 60.0
+
+# Tight ceiling for the new-session-modal-open path so a slow network or
+# unauthenticated ``gh`` never delays the modal opening. On timeout the
+# call returns an empty list and the picker is hidden silently.
+_LIST_ISSUES_TIMEOUT_S = 5.0
+
+# Cap on the issue body length we splice into the agent prompt. Long
+# issue bodies can balloon prompt size and push past the model's context
+# window for no real benefit; the agent can always re-read the URL if it
+# needs the full text.
+_BODY_TRUNCATION_LIMIT = 8000
+_BODY_TRUNCATION_MARKER = "\n\n…(truncated)…"
+
+
+def _no_prompt_env() -> dict[str, str]:
+    """Env that forbids git/ssh from waiting on an interactive credential prompt.
+
+    Without these, ``git push`` inheriting the TUI's TTY can either block on
+    stdin (raw mode swallows the keypresses git expects) or scribble a
+    password prompt onto the screen — both manifest as "TUI got laggy and
+    nothing happened." With them set, git/ssh fail fast with an auth error
+    that surfaces as a PR_FAILED toast.
+    """
+    env = dict(os.environ)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env.setdefault("GIT_ASKPASS", "/bin/true")
+    env.setdefault("SSH_ASKPASS", "/bin/true")
+    env.setdefault("SSH_ASKPASS_REQUIRE", "never")
+    return env
+
+
+async def _run(
+    cmd: list[str],
+    cwd: Path | None = None,
+    *,
+    timeout: float = _RUN_TIMEOUT_S,
+) -> tuple[int, str, str]:
+    """Run a subprocess, returning (returncode, stdout, stderr).
+
+    stdin is wired to /dev/null so git/gh can never read from the parent
+    TTY, and a wall-clock ``timeout`` kills any process that still hangs
+    despite that — preserving the invariant that callers always reach
+    their post-await cleanup paths.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=str(cwd) if cwd is not None else None,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=_no_prompt_env(),
+    )
+    try:
+        out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        log.warning("gh._run timeout after %.0fs: %s", timeout, cmd)
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        return (-1, "", f"timed out after {timeout:.0f}s")
+    return (
+        proc.returncode if proc.returncode is not None else -1,
+        out_b.decode(errors="replace").strip(),
+        err_b.decode(errors="replace").strip(),
+    )
+
+
+@dataclass(frozen=True)
+class Issue:
+    """A GitHub issue surfaced for the new-session picker.
+
+    Frozen because instances cross modal boundaries and end up baked into
+    ``NewSessionResult``; immutability rules out a stale-reference bug if
+    the underlying list is ever mutated.
+    """
+
+    number: int
+    title: str
+    url: str
+    body: str
+    state: str  # "OPEN" | "CLOSED" — only OPEN is fetched today, kept for clarity.
+
+
+def is_available() -> bool:
+    """Return True iff the ``gh`` CLI is on PATH.
+
+    Cheap pre-flight so the new-session flow can skip spawning subprocesses
+    on machines without GitHub CLI installed.
+    """
+    return shutil.which("gh") is not None
+
+
+async def list_issues(
+    repo_path: Path,
+    *,
+    limit: int = 20,
+    timeout: float = _LIST_ISSUES_TIMEOUT_S,
+) -> list[Issue]:
+    """Best-effort list of recent open issues for the repo at ``repo_path``.
+
+    Calls ``gh issue list --state open --limit N --json number,title,url,body,state``
+    with ``cwd=repo_path`` so ``gh`` infers the GitHub repo from the local
+    remote. Normalizes CRLF → LF in the body so downstream prompt formatting
+    stays clean.
+
+    Every failure mode — non-zero exit (no auth, no remote, not GitHub-
+    hosted), timeout, malformed JSON, missing keys — collapses to an empty
+    list and a WARNING log line. The caller treats empty-list as "no
+    picker," which is exactly what we want for the silent-degrade UX.
+    """
+    rc, out, err = await _run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,url,body,state",
+        ],
+        cwd=repo_path,
+        timeout=timeout,
+    )
+    if rc != 0:
+        log.warning("gh issue list failed (rc=%d) in %s: %s", rc, repo_path, err)
+        return []
+    if not out:
+        return []
+    try:
+        raw = json.loads(out)
+    except json.JSONDecodeError as e:
+        log.warning("gh issue list returned invalid JSON in %s: %s", repo_path, e)
+        return []
+    if not isinstance(raw, list):
+        log.warning("gh issue list JSON is not a list in %s: %r", repo_path, type(raw))
+        return []
+    issues: list[Issue] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        try:
+            issues.append(
+                Issue(
+                    number=int(item["number"]),
+                    title=str(item["title"]),
+                    url=str(item["url"]),
+                    body=str(item.get("body", "") or "").replace("\r\n", "\n"),
+                    state=str(item.get("state", "OPEN")),
+                )
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            log.warning("gh issue list item skipped (%s): %r", e, item)
+            continue
+    return issues
+
+
+def build_issue_prompt(issue: Issue, user_prompt: str) -> str:
+    """Render the agent's initial prompt with a linked GitHub issue prepended.
+
+    Layout::
+
+        GitHub issue #{number}: {title}
+        {url}
+
+        {body}
+
+        ---
+
+        {user_prompt}
+
+    The body is truncated at ``_BODY_TRUNCATION_LIMIT`` characters with an
+    explicit marker so the agent can tell content was cut. If the body is
+    blank/whitespace-only the body block is omitted entirely (no dangling
+    empty section before the ``---`` separator).
+    """
+    body = issue.body.strip()
+    if len(body) > _BODY_TRUNCATION_LIMIT:
+        body = body[:_BODY_TRUNCATION_LIMIT] + _BODY_TRUNCATION_MARKER
+
+    head = f"GitHub issue #{issue.number}: {issue.title}\n{issue.url}"
+    user_part = user_prompt.strip()
+    if body:
+        return f"{head}\n\n{body}\n\n---\n\n{user_part}"
+    return f"{head}\n\n---\n\n{user_part}"

--- a/src/chud/manager.py
+++ b/src/chud/manager.py
@@ -58,6 +58,7 @@ class SessionManager:
         options: dict[str, bool] | None = None,
         launch_cwd: Path | None = None,
         effort: str | None = None,
+        issue_number: int | None = None,
     ) -> AgentSession:
         sid = _new_session_id()
         workspace = state_mod.workspaces_root() / sid
@@ -67,6 +68,7 @@ class SessionManager:
             initial_prompt=prompt,
             options=normalize_options(options),
             effort=normalize_effort(effort),
+            issue_number=issue_number,
         )
 
         wt_mgr = WorktreeManager(st)

--- a/src/chud/pr.py
+++ b/src/chud/pr.py
@@ -178,7 +178,21 @@ def pick_body(state: SessionState) -> str:
     """Prefer the plan's ``## Context`` section as the body lead, with a
     small footer pointing back to the chud session id. Fall back to the
     prompt-only body when no plan is available.
+
+    When the session is linked to a GitHub issue, prepend a ``Closes #N``
+    line so GitHub auto-populates the Development sidebar — this is the
+    signal the new-session picker reads back via
+    ``Issue.closing_pr_numbers`` to filter the issue out of future picker
+    opens. Users can still strip the line in the PR-review modal if they
+    don't want the auto-close behavior.
     """
+    body = _pick_body_inner(state)
+    if state.issue_number is not None:
+        return f"Closes #{state.issue_number}\n\n{body}"
+    return body
+
+
+def _pick_body_inner(state: SessionState) -> str:
     if state.approved_plan:
         context = _extract_plan_context(state.approved_plan)
         if context:

--- a/src/chud/pr.py
+++ b/src/chud/pr.py
@@ -13,15 +13,13 @@ so PRs read as summaries of *what was done* rather than verbatim user input.
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import logging
-import os
 import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from chud.gh import _no_prompt_env, _run
 from chud.settings import render_pr_body_footer
 from chud.types import SessionState
 
@@ -30,11 +28,17 @@ log = logging.getLogger(__name__)
 
 _TITLE_LIMIT = 72
 
-# A real GitHub push completes in a few seconds; anything past this is a
-# hang, typically a credential prompt that the TUI's raw-mode terminal
-# can't satisfy. Without this guard, _publish_prs parks forever and the
-# post-DONE CLEANUP_REQUESTED broadcast never fires.
-_RUN_TIMEOUT_S = 60.0
+# Re-exported so existing tests that monkeypatch ``chud.pr._run`` keep
+# working without churn. Internal callers in this module still resolve
+# ``_run`` through the local module dict, which the tests override.
+__all__ = [
+    "PRResult",
+    "_no_prompt_env",
+    "_run",
+    "publish_draft_prs",
+    "pick_title",
+    "pick_body",
+]
 
 
 @dataclass
@@ -44,55 +48,6 @@ class PRResult:
     url: str | None = None
     error: str | None = None
     discarded: bool = False
-
-
-def _no_prompt_env() -> dict[str, str]:
-    """Env that forbids git/ssh from waiting on an interactive credential prompt.
-
-    Without these, ``git push`` inheriting the TUI's TTY can either block on
-    stdin (raw mode swallows the keypresses git expects) or scribble a
-    password prompt onto the screen — both manifest as "TUI got laggy and
-    nothing happened." With them set, git/ssh fail fast with an auth error
-    that surfaces as a PR_FAILED toast.
-    """
-    env = dict(os.environ)
-    env["GIT_TERMINAL_PROMPT"] = "0"
-    env.setdefault("GIT_ASKPASS", "/bin/true")
-    env.setdefault("SSH_ASKPASS", "/bin/true")
-    env.setdefault("SSH_ASKPASS_REQUIRE", "never")
-    return env
-
-
-async def _run(cmd: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
-    """Run a subprocess, returning (returncode, stdout, stderr).
-
-    stdin is wired to /dev/null so git/gh can never read from the parent
-    TTY, and a 60s wall-clock timeout kills any process that still hangs
-    despite that — preserving the invariant that ``_finish_done`` always
-    reaches its CLEANUP_REQUESTED broadcast.
-    """
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        cwd=str(cwd) if cwd is not None else None,
-        stdin=asyncio.subprocess.DEVNULL,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=_no_prompt_env(),
-    )
-    try:
-        out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=_RUN_TIMEOUT_S)
-    except TimeoutError:
-        log.warning("pr._run timeout after %.0fs: %s", _RUN_TIMEOUT_S, cmd)
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-        with contextlib.suppress(Exception):
-            await proc.wait()
-        return (-1, "", f"timed out after {_RUN_TIMEOUT_S:.0f}s")
-    return (
-        proc.returncode if proc.returncode is not None else -1,
-        out_b.decode(errors="replace").strip(),
-        err_b.decode(errors="replace").strip(),
-    )
 
 
 async def _default_branch(repo_path: Path) -> str:

--- a/src/chud/types.py
+++ b/src/chud/types.py
@@ -22,6 +22,7 @@ KEY_ERROR = "error"
 KEY_OPTIONS = "options"
 KEY_APPROVED_PLAN = "approved_plan"
 KEY_EFFORT = "effort"
+KEY_ISSUE_NUMBER = "issue_number"
 
 
 class SessionStatus(StrEnum):
@@ -70,6 +71,10 @@ class SessionState:
     options: dict[str, bool] = field(default_factory=dict)
     approved_plan: str | None = None
     effort: str | None = None
+    # GitHub issue number this session was launched from, if any. Set when
+    # the user picks an issue in the new-session modal; consumed by callers
+    # that want to surface "an existing chud is working on issue #N" hints.
+    issue_number: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -85,6 +90,7 @@ class SessionState:
             KEY_OPTIONS: dict(self.options),
             KEY_APPROVED_PLAN: self.approved_plan,
             KEY_EFFORT: self.effort,
+            KEY_ISSUE_NUMBER: self.issue_number,
         }
 
     @classmethod
@@ -107,6 +113,7 @@ class SessionState:
             options=normalize_options(d.get(KEY_OPTIONS)),
             approved_plan=d.get(KEY_APPROVED_PLAN),
             effort=normalize_effort(d.get(KEY_EFFORT)),
+            issue_number=d.get(KEY_ISSUE_NUMBER),
         )
 
 

--- a/src/chud/widgets/new_session_modal.py
+++ b/src/chud/widgets/new_session_modal.py
@@ -8,7 +8,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Label, Select, Static, TextArea
 
-from chud.gh import Issue
+from chud.gh import Issue, build_issue_prompt
 from chud.options import EFFORT_VALUES, SESSION_OPTIONS
 from chud.state import (
     claude_settings_effort,
@@ -20,6 +20,12 @@ from chud.state import (
 from chud.types import KEY_EFFORT
 
 _EFFORT_CHOICES: tuple[tuple[str, str], ...] = tuple((v.capitalize(), v) for v in EFFORT_VALUES)
+
+# Glyph prefix used in the issue picker to mark issues that already have an
+# active (non-terminal) chud session linked to them. Avoid bracket-wrapped
+# text — Textual's Select renders option labels through Rich markup, so
+# ``[…]`` would be eaten as a tag.
+ACTIVE_CHUD_ICON = "⚙"
 
 
 @dataclass
@@ -40,9 +46,11 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
 
     When chud is launched inside a repo and ``gh`` is available, the caller
     can pass a list of recent open issues into ``issues``; the modal then
-    renders an optional GitHub-issue picker between the prompt and the
-    options group. Selecting an issue tells the caller to fold its title,
-    URL, and body into the agent's initial prompt before kickoff.
+    renders an optional GitHub-issue picker above the prompt. Selecting an
+    issue pre-populates the prompt textarea with the issue's title, URL,
+    body, and a ``---`` separator so the user can append additional context
+    before submitting; the resulting ``NewSessionResult.prompt`` already
+    contains the merged text and the caller passes it to the agent as-is.
     """
 
     DEFAULT_CSS = """
@@ -107,27 +115,64 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
         Binding("f2", "start", "Start", priority=True),
     ]
 
-    def __init__(self, issues: list[Issue] | None = None) -> None:
+    # Tell Textual which widget to focus on screen mount, BEFORE the first
+    # paint. Without this, the screen auto-focuses the first focusable
+    # widget in compose order — now the issue Select since it sits above
+    # the prompt — and our ``on_mount`` reassignment to the prompt fires
+    # one frame later, producing a visible flash on the issue picker.
+    AUTO_FOCUS = "#prompt"
+
+    def __init__(
+        self,
+        issues: list[Issue] | None = None,
+        active_sessions_by_issue: dict[int, list[str]] | None = None,
+    ) -> None:
         super().__init__()
         # Normalize ``None`` and ``[]`` to "no picker" via ``bool(self._issues)``;
         # the caller already collapses both gh-missing and empty-list cases to
         # ``None``, but we re-check here so the modal stays robust if invoked
         # directly (e.g. from tests) with an empty list.
         self._issues: list[Issue] = list(issues) if issues else []
+        # Last text we auto-populated into the prompt textarea on issue
+        # selection. Used to detect "user hasn't edited it" so re-selecting a
+        # different issue replaces cleanly without stomping manual edits.
+        self._last_autopopulated: str = ""
+        # {issue_number: [session_id, ...]} for active (non-terminal) chud
+        # sessions already linked to each issue. Used to decorate the picker
+        # labels so the user can see an existing chud is on an issue before
+        # spawning a duplicate. Empty by default — callers that don't pass
+        # this in just get plain labels.
+        self._active_by_issue: dict[int, list[str]] = dict(active_sessions_by_issue or {})
 
     @property
     def _has_issue_picker(self) -> bool:
         return bool(self._issues)
 
+    def _format_issue_label(self, issue: Issue) -> str:
+        """Render the dropdown label for an issue, prefixing a gear icon when
+        an active chud session is already linked to it. The count is appended
+        only when more than one chud is on the same issue.
+
+        Examples:
+          ``#42 — Tighten retries``           (no active session)
+          ``⚙ #42 — Tighten retries``         (one active session)
+          ``⚙×2 #42 — Tighten retries``       (multiple)
+        """
+        base = f"#{issue.number} — {issue.title}"
+        active = self._active_by_issue.get(issue.number, [])
+        if not active:
+            return base
+        if len(active) == 1:
+            return f"{ACTIVE_CHUD_ICON} {base}"
+        return f"{ACTIVE_CHUD_ICON}×{len(active)} {base}"
+
     def compose(self) -> ComposeResult:
         with Vertical():
             yield Static("[bold]New session[/bold]")
-            yield Label("Initial prompt:")
-            yield TextArea("", id="prompt")
             if self._has_issue_picker:
                 yield Label("Link GitHub issue (optional):")
                 issue_choices = tuple(
-                    (f"#{i.number} — {i.title}", str(i.number)) for i in self._issues
+                    (self._format_issue_label(i), str(i.number)) for i in self._issues
                 )
                 yield Select(
                     issue_choices,
@@ -135,11 +180,13 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
                     allow_blank=True,
                     prompt="(none — start without an issue)",
                     tooltip=(
-                        "Optionally pre-load a GitHub issue's title, URL, and body "
-                        "into the agent's initial prompt. The text you typed above "
-                        "is appended after a `---` separator."
+                        "Pick a GitHub issue to pre-populate the prompt with its "
+                        "title, URL, and body. You can edit the text afterwards "
+                        "to add extra context before submitting."
                     ),
                 )
+            yield Label("Initial prompt:")
+            yield TextArea("", id="prompt")
             defaults = user_default_options()
             with VerticalScroll(id="options-group"):
                 yield Label("Options")
@@ -180,6 +227,41 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
         elif event.button.id == "start":
             self._submit()
 
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Pre-populate the prompt textarea when the user picks an issue.
+
+        Only overwrites when the textarea is empty or still holds the text we
+        last auto-populated (so re-picking a different issue swaps cleanly,
+        but manual edits aren't stomped). When the picker is cleared back to
+        blank, restore the textarea to whatever it held before any
+        auto-population.
+        """
+        if event.select.id != "issue":
+            return
+        prompt_area = self.query_one("#prompt", TextArea)
+        current = prompt_area.text
+        if current and current != self._last_autopopulated:
+            self.app.notify(
+                "Prompt has been edited; not overwriting. Clear it manually to "
+                "load a different issue.",
+                severity="warning",
+            )
+            return
+
+        raw = event.value
+        if not isinstance(raw, str):
+            prompt_area.text = ""
+            self._last_autopopulated = ""
+            return
+        issue = next((i for i in self._issues if str(i.number) == raw), None)
+        if issue is None:
+            return
+        # Pass an empty user_prompt so we get just the issue head + body + "---"
+        # separator; the user types their additions below the separator.
+        merged = build_issue_prompt(issue, "")
+        prompt_area.text = merged
+        self._last_autopopulated = merged
+
     def _save_defaults(self) -> None:
         options = {
             opt.id: self.query_one(f"#opt-{opt.id}", Checkbox).value for opt in SESSION_OPTIONS
@@ -204,9 +286,6 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
 
     def action_start(self) -> None:
         self._submit()
-
-    def on_mount(self) -> None:
-        self.query_one("#prompt", TextArea).focus()
 
     def _read_issue(self) -> Issue | None:
         """Resolve the ``Select#issue`` value to an ``Issue``, or ``None``.

--- a/src/chud/widgets/new_session_modal.py
+++ b/src/chud/widgets/new_session_modal.py
@@ -8,6 +8,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Label, Select, Static, TextArea
 
+from chud.gh import Issue
 from chud.options import EFFORT_VALUES, SESSION_OPTIONS
 from chud.state import (
     claude_settings_effort,
@@ -26,6 +27,7 @@ class NewSessionResult:
     prompt: str
     options: dict[str, bool] = field(default_factory=user_default_options)
     effort: str | None = None
+    issue: Issue | None = None
 
 
 class NewSessionModal(ModalScreen[NewSessionResult | None]):
@@ -35,6 +37,12 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
     (see ``chud.worktree.detect_cwd_repo``); when chud isn't inside a git
     repo, the session starts unattached and the agent uses the
     ``mcp__chud__attach_repo`` tool to attach repos itself.
+
+    When chud is launched inside a repo and ``gh`` is available, the caller
+    can pass a list of recent open issues into ``issues``; the modal then
+    renders an optional GitHub-issue picker between the prompt and the
+    options group. Selecting an issue tells the caller to fold its title,
+    URL, and body into the agent's initial prompt before kickoff.
     """
 
     DEFAULT_CSS = """
@@ -44,7 +52,8 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
     NewSessionModal > Vertical {
         width: 90%;
         max-width: 100;
-        height: 36;
+        height: auto;
+        max-height: 90%;
         background: $surface;
         border: round $accent;
         padding: 1 2;
@@ -55,6 +64,9 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
     }
     NewSessionModal TextArea {
         height: 8;
+        margin-bottom: 1;
+    }
+    NewSessionModal #issue {
         margin-bottom: 1;
     }
     NewSessionModal #options-group {
@@ -95,11 +107,39 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
         Binding("f2", "start", "Start", priority=True),
     ]
 
+    def __init__(self, issues: list[Issue] | None = None) -> None:
+        super().__init__()
+        # Normalize ``None`` and ``[]`` to "no picker" via ``bool(self._issues)``;
+        # the caller already collapses both gh-missing and empty-list cases to
+        # ``None``, but we re-check here so the modal stays robust if invoked
+        # directly (e.g. from tests) with an empty list.
+        self._issues: list[Issue] = list(issues) if issues else []
+
+    @property
+    def _has_issue_picker(self) -> bool:
+        return bool(self._issues)
+
     def compose(self) -> ComposeResult:
         with Vertical():
             yield Static("[bold]New session[/bold]")
             yield Label("Initial prompt:")
             yield TextArea("", id="prompt")
+            if self._has_issue_picker:
+                yield Label("Link GitHub issue (optional):")
+                issue_choices = tuple(
+                    (f"#{i.number} — {i.title}", str(i.number)) for i in self._issues
+                )
+                yield Select(
+                    issue_choices,
+                    id="issue",
+                    allow_blank=True,
+                    prompt="(none — start without an issue)",
+                    tooltip=(
+                        "Optionally pre-load a GitHub issue's title, URL, and body "
+                        "into the agent's initial prompt. The text you typed above "
+                        "is appended after a `---` separator."
+                    ),
+                )
             defaults = user_default_options()
             with VerticalScroll(id="options-group"):
                 yield Label("Options")
@@ -168,6 +208,21 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
     def on_mount(self) -> None:
         self.query_one("#prompt", TextArea).focus()
 
+    def _read_issue(self) -> Issue | None:
+        """Resolve the ``Select#issue`` value to an ``Issue``, or ``None``.
+
+        ``Select.value`` returns the ``BLANK`` sentinel (not a ``str``) when
+        the user hasn't picked anything, which collapses to ``None`` here.
+        Otherwise we look up the matching issue by number — comparing as
+        strings since ``Select`` round-trips option values verbatim.
+        """
+        if not self._has_issue_picker:
+            return None
+        raw = self.query_one("#issue", Select).value
+        if not isinstance(raw, str):
+            return None
+        return next((i for i in self._issues if str(i.number) == raw), None)
+
     def _submit(self) -> None:
         prompt = self.query_one("#prompt", TextArea).text.strip()
         if not prompt:
@@ -180,5 +235,6 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
                 prompt=prompt,
                 options=options,
                 effort=self._read_effort(),
+                issue=self._read_issue(),
             )
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from chud import gh as gh_mod
 from chud import state as state_mod
 
 
@@ -23,3 +24,17 @@ def _isolate_user_config(tmp_path_factory, monkeypatch):
     monkeypatch.setenv("HOME", str(home))
     cfg = tmp_path_factory.mktemp("chud-cfg") / "config.json"
     monkeypatch.setattr(state_mod, "config_file", lambda: Path(cfg))
+
+
+@pytest.fixture(autouse=True)
+def _disable_gh_at_startup(request, monkeypatch):
+    """Pretend ``gh`` is missing so ``ChudApp.on_mount`` doesn't kick off a
+    real ``gh issue list`` against whatever repo the test process happens to
+    sit in. Tests that exercise the issues flow seed ``app._issues_cache``
+    directly instead of relying on the background refresh.
+
+    Skipped for ``test_gh.py``, which exercises the real ``gh`` module
+    surface (including ``is_available``) and would fail with this stub."""
+    if "test_gh.py" in request.node.nodeid:
+        return
+    monkeypatch.setattr(gh_mod, "is_available", lambda: False)

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -22,7 +22,11 @@ from chud.gh import Issue
 from chud.types import Event, EventKind, SessionState, SessionStatus, Worktree
 from chud.widgets.attach_repo_modal import AttachRepoModal
 from chud.widgets.cleanup_confirmation_modal import CleanupConfirmationModal
-from chud.widgets.new_session_modal import NewSessionModal, NewSessionResult
+from chud.widgets.new_session_modal import (
+    ACTIVE_CHUD_ICON,
+    NewSessionModal,
+    NewSessionResult,
+)
 from chud.widgets.plan_modal import PlanApprovalModal
 from chud.widgets.session_list import SessionListView, SessionRow
 from chud.widgets.session_view import SessionView
@@ -481,11 +485,150 @@ async def test_new_session_modal_with_empty_issues_hides_picker():
         _force_render(modal)
 
 
+async def test_new_session_modal_picker_populates_prompt():
+    """Selecting an issue from the picker pre-fills the prompt textarea with
+    the issue's title + URL + body + ``---`` separator."""
+    from textual.widgets import TextArea
+
+    issue = _sample_issue(number=42, title="Picker test")
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal(issues=[issue]))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+        select = modal.query_one("#issue", Select)
+        select.value = str(issue.number)
+        await pilot.pause()
+        text = modal.query_one("#prompt", TextArea).text
+        assert "GitHub issue #42: Picker test" in text
+        assert "https://github.com/x/y/issues/42" in text
+        assert "ctx body" in text
+        assert "\n---\n" in text
+
+
+async def test_new_session_flow_filters_issues_with_open_pr(monkeypatch):
+    """End-to-end: an issue listed in ``_issues_with_pr_cache`` (populated
+    by the background ``gh.list_issue_numbers_with_open_pr`` refresh) is
+    dropped from the picker regardless of who or what made the PR."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        monkeypatch.setattr("chud.app.detect_cwd_repo", lambda: Path("/fake/repo"))
+
+        keep = _sample_issue(number=10, title="open work")
+        drop = _sample_issue(number=11, title="already in PR")
+        app._issues_cache = [keep, drop]
+        app._issues_with_pr_cache = {11}
+        app._launch_repo = Path("/fake/repo")
+
+        captured: dict[str, Any] = {}
+
+        async def fake_push_screen_wait(modal: Any) -> NewSessionResult | None:
+            assert isinstance(modal, NewSessionModal)
+            captured["issues"] = list(modal._issues)
+            return None
+
+        monkeypatch.setattr(app, "push_screen_wait", fake_push_screen_wait)
+
+        await app._new_session_flow()
+        seen_numbers = [i.number for i in captured["issues"]]
+        assert 10 in seen_numbers
+        assert 11 not in seen_numbers
+
+
+async def test_app_active_sessions_by_issue_skips_terminal_states():
+    """``ChudApp._active_sessions_by_issue`` only counts sessions whose status
+    is non-terminal (DONE/ERRORED are excluded — those chuds aren't 'working'
+    anymore)."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        def _stub(sid: str, issue_num: int | None, status: SessionStatus) -> Any:
+            state = SessionState(
+                id=sid,
+                workspace_dir=Path(f"/tmp/{sid}"),
+                issue_number=issue_num,
+            )
+            state.status = status
+            return SimpleNamespace(state=state)
+
+        app.manager.sessions = {  # type: ignore[assignment]
+            "a": _stub("a", 7, SessionStatus.EXECUTING),
+            "b": _stub("b", 7, SessionStatus.AWAITING_USER),
+            "c": _stub("c", 7, SessionStatus.DONE),
+            "d": _stub("d", 9, SessionStatus.ERRORED),
+            "e": _stub("e", None, SessionStatus.EXECUTING),
+        }
+        try:
+            out = app._active_sessions_by_issue()
+            assert sorted(out.keys()) == [7]
+            assert sorted(out[7]) == ["a", "b"]
+        finally:
+            # Clear before teardown — the manager's shutdown iterates sessions
+            # and calls .stop() on each, which our SimpleNamespace stubs lack.
+            app.manager.sessions = {}
+
+
+async def test_new_session_modal_marks_issues_with_active_chud():
+    """Issues that already have an active chud session linked to them get a
+    ``[chud working]`` prefix in the picker label so the user knows before
+    spawning a duplicate."""
+    one = _sample_issue(number=1, title="solo")
+    two = _sample_issue(number=2, title="busy")
+    three = _sample_issue(number=3, title="crowded")
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = NewSessionModal(
+            issues=[one, two, three],
+            active_sessions_by_issue={2: ["sess-A"], 3: ["sess-A", "sess-B"]},
+        )
+        labels = {i.number: modal._format_issue_label(i) for i in [one, two, three]}
+        assert labels[1] == "#1 — solo"
+        assert labels[2] == f"{ACTIVE_CHUD_ICON} #2 — busy"
+        assert labels[3] == f"{ACTIVE_CHUD_ICON}×2 #3 — crowded"
+        # Drive the modal through compose() to make sure the helper actually
+        # feeds Select.
+        app.push_screen(modal)
+        await pilot.pause()
+        select = app.screen.query_one("#issue", Select)
+        rendered = {pair[1]: pair[0] for pair in select._options}  # type: ignore[attr-defined]
+        assert rendered[str(2)] == f"{ACTIVE_CHUD_ICON} #2 — busy"
+        assert rendered[str(3)] == f"{ACTIVE_CHUD_ICON}×2 #3 — crowded"
+
+
+async def test_new_session_modal_picker_does_not_clobber_user_edits():
+    """If the user has already typed something the picker must not overwrite
+    it on issue selection."""
+    from textual.widgets import TextArea
+
+    issue = _sample_issue(number=8, title="Don't overwrite me")
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal(issues=[issue]))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+        prompt_area = modal.query_one("#prompt", TextArea)
+        prompt_area.text = "user typed this first"
+        select = modal.query_one("#issue", Select)
+        select.value = str(issue.number)
+        await pilot.pause()
+        assert modal.query_one("#prompt", TextArea).text == "user typed this first"
+
+
 # --- New-session flow: issue → templated prompt ------------------------------
 
 
-async def test_new_session_flow_injects_issue_into_prompt(monkeypatch):
-    """End-to-end: picking an issue templates it into the create_session prompt."""
+async def test_new_session_flow_passes_modal_prompt_through_for_issue(monkeypatch):
+    """The modal now pre-populates the prompt with the issue content (see
+    NewSessionModal.on_select_changed) and returns the merged text in
+    ``NewSessionResult.prompt``. The flow must pass it through verbatim — no
+    second prepend, otherwise the issue head would appear twice."""
     app = ChudApp()
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -495,12 +638,11 @@ async def test_new_session_flow_injects_issue_into_prompt(monkeypatch):
         monkeypatch.setattr(gh_mod, "is_available", lambda: True)
         issue = _sample_issue(number=7, title="Tighten retries")
 
-        async def fake_list_issues(_repo, **_kw):
-            return [issue]
+        # Seed the cache directly — the flow reads from the background-refreshed
+        # cache rather than awaiting a fresh fetch on each `n` press.
+        app._issues_cache = [issue]
+        app._launch_repo = Path("/fake/repo")
 
-        monkeypatch.setattr(gh_mod, "list_issues", fake_list_issues)
-
-        # Capture the prompt that would reach the agent runtime.
         captured: dict[str, Any] = {}
 
         async def fake_create_session(
@@ -522,15 +664,16 @@ async def test_new_session_flow_injects_issue_into_prompt(monkeypatch):
 
         monkeypatch.setattr(app.manager, "create_session", fake_create_session)
 
-        # Replace push_screen_wait with a stub that returns a synthetic result
-        # carrying the picked issue. This avoids having to drive the modal via
-        # keystrokes — we're testing the flow's plumbing, not Textual's input.
+        # Modal stub returns what a real modal would produce when the user
+        # picks the issue and then types extra context: the issue head + body
+        # + "---" + their additions, all already in `prompt`.
+        merged_prompt = gh_mod.build_issue_prompt(issue, "please fix it")
+
         async def fake_push_screen_wait(modal: Any) -> NewSessionResult:
             assert isinstance(modal, NewSessionModal)
-            # The picker should have been mounted with our issue.
             assert modal._has_issue_picker
             return NewSessionResult(
-                prompt="please fix it",
+                prompt=merged_prompt,
                 options={},
                 effort=None,
                 issue=issue,
@@ -541,12 +684,13 @@ async def test_new_session_flow_injects_issue_into_prompt(monkeypatch):
         await app._new_session_flow()
 
         prompt = captured["prompt"]
+        assert prompt == merged_prompt, "flow must not re-prepend issue content"
+        # Sanity: the merged text contains the expected issue pieces.
         assert "GitHub issue #7: Tighten retries" in prompt
         assert "https://github.com/x/y/issues/7" in prompt
         assert "ctx body" in prompt
         assert "\n---\n" in prompt
         assert prompt.rstrip().endswith("please fix it")
-        # And the repo flowed through to the manager.
         assert captured["repo_path"] == Path("/fake/repo")
 
 

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -11,12 +11,18 @@ widget for its strips so the render pipeline runs end-to-end.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
+from textual.widgets import Select
+
+from chud import gh as gh_mod
 from chud.app import ChudApp
+from chud.gh import Issue
 from chud.types import Event, EventKind, SessionState, SessionStatus, Worktree
 from chud.widgets.attach_repo_modal import AttachRepoModal
 from chud.widgets.cleanup_confirmation_modal import CleanupConfirmationModal
-from chud.widgets.new_session_modal import NewSessionModal
+from chud.widgets.new_session_modal import NewSessionModal, NewSessionResult
 from chud.widgets.plan_modal import PlanApprovalModal
 from chud.widgets.session_list import SessionListView, SessionRow
 from chud.widgets.session_view import SessionView
@@ -418,3 +424,247 @@ async def test_cleanup_modal_published_swaps_to_success_copy():
         assert "https://github.com/a/b/pull/2" in text
         assert "permanently delete" not in text
         assert "will be lost" not in text
+
+
+# --- New-session modal: GitHub issue picker ----------------------------------
+
+
+def _sample_issue(number: int = 7, title: str = "t") -> Issue:
+    return Issue(
+        number=number,
+        title=title,
+        url=f"https://github.com/x/y/issues/{number}",
+        body="ctx body",
+        state="OPEN",
+    )
+
+
+async def test_new_session_modal_with_issues_renders_picker():
+    """Picker Select is mounted and rendered when issues are provided."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal(issues=[_sample_issue()]))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+        # Query the modal screen specifically — the picker lives there, not on
+        # the app's default screen.
+        select = modal.query_one("#issue", Select)
+        assert select is not None
+        _force_render(modal)
+
+
+async def test_new_session_modal_without_issues_hides_picker():
+    """``issues=None`` ⇒ no Select#issue in the DOM."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal(issues=None))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+        assert len(modal.query("#issue")) == 0
+        _force_render(modal)
+
+
+async def test_new_session_modal_with_empty_issues_hides_picker():
+    """``issues=[]`` is treated identically to ``None``."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal(issues=[]))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+        assert len(modal.query("#issue")) == 0
+        _force_render(modal)
+
+
+# --- New-session flow: issue → templated prompt ------------------------------
+
+
+async def test_new_session_flow_injects_issue_into_prompt(monkeypatch):
+    """End-to-end: picking an issue templates it into the create_session prompt."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        # Pretend we're inside a repo and gh is happy.
+        monkeypatch.setattr("chud.app.detect_cwd_repo", lambda: Path("/fake/repo"))
+        monkeypatch.setattr(gh_mod, "is_available", lambda: True)
+        issue = _sample_issue(number=7, title="Tighten retries")
+
+        async def fake_list_issues(_repo, **_kw):
+            return [issue]
+
+        monkeypatch.setattr(gh_mod, "list_issues", fake_list_issues)
+
+        # Capture the prompt that would reach the agent runtime.
+        captured: dict[str, Any] = {}
+
+        async def fake_create_session(
+            prompt: str,
+            repo_path: Path | None = None,
+            launch_cwd: Path | None = None,
+            options: dict[str, bool] | None = None,
+            effort: str | None = None,
+            **_kw: Any,
+        ) -> Any:
+            captured["prompt"] = prompt
+            captured["repo_path"] = repo_path
+            state = SessionState(
+                id="sessISSUE",
+                workspace_dir=Path("/tmp/ws"),
+                initial_prompt=prompt,
+            )
+            return SimpleNamespace(state=state)
+
+        monkeypatch.setattr(app.manager, "create_session", fake_create_session)
+
+        # Replace push_screen_wait with a stub that returns a synthetic result
+        # carrying the picked issue. This avoids having to drive the modal via
+        # keystrokes — we're testing the flow's plumbing, not Textual's input.
+        async def fake_push_screen_wait(modal: Any) -> NewSessionResult:
+            assert isinstance(modal, NewSessionModal)
+            # The picker should have been mounted with our issue.
+            assert modal._has_issue_picker
+            return NewSessionResult(
+                prompt="please fix it",
+                options={},
+                effort=None,
+                issue=issue,
+            )
+
+        monkeypatch.setattr(app, "push_screen_wait", fake_push_screen_wait)
+
+        await app._new_session_flow()
+
+        prompt = captured["prompt"]
+        assert "GitHub issue #7: Tighten retries" in prompt
+        assert "https://github.com/x/y/issues/7" in prompt
+        assert "ctx body" in prompt
+        assert "\n---\n" in prompt
+        assert prompt.rstrip().endswith("please fix it")
+        # And the repo flowed through to the manager.
+        assert captured["repo_path"] == Path("/fake/repo")
+
+
+async def test_new_session_flow_no_issue_passes_prompt_verbatim(monkeypatch):
+    """If the user doesn't pick an issue, the prompt reaches create_session unchanged."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        monkeypatch.setattr("chud.app.detect_cwd_repo", lambda: Path("/fake/repo"))
+        monkeypatch.setattr(gh_mod, "is_available", lambda: True)
+
+        async def fake_list_issues(_repo, **_kw):
+            return [_sample_issue()]
+
+        monkeypatch.setattr(gh_mod, "list_issues", fake_list_issues)
+
+        captured: dict[str, Any] = {}
+
+        async def fake_create_session(
+            prompt: str,
+            repo_path: Path | None = None,
+            launch_cwd: Path | None = None,
+            options: dict[str, bool] | None = None,
+            effort: str | None = None,
+            **_kw: Any,
+        ) -> Any:
+            captured["prompt"] = prompt
+            return SimpleNamespace(
+                state=SessionState(
+                    id="sessNO",
+                    workspace_dir=Path("/tmp/ws"),
+                    initial_prompt=prompt,
+                )
+            )
+
+        monkeypatch.setattr(app.manager, "create_session", fake_create_session)
+
+        async def fake_push_screen_wait(_modal: Any) -> NewSessionResult:
+            return NewSessionResult(
+                prompt="just do the thing",
+                options={},
+                effort=None,
+                issue=None,
+            )
+
+        monkeypatch.setattr(app, "push_screen_wait", fake_push_screen_wait)
+
+        await app._new_session_flow()
+
+        assert captured["prompt"] == "just do the thing"
+
+
+async def test_new_session_flow_no_repo_skips_gh(monkeypatch):
+    """When CWD isn't a repo, ``list_issues`` is never called and modal gets ``None``."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        monkeypatch.setattr("chud.app.detect_cwd_repo", lambda: None)
+
+        list_calls: list[Path] = []
+
+        async def fake_list_issues(repo, **_kw):
+            list_calls.append(repo)
+            return []
+
+        monkeypatch.setattr(gh_mod, "list_issues", fake_list_issues)
+        # Don't even let is_available short-circuit hide the call — the
+        # detect-cwd-repo branch should bail before reaching this.
+        monkeypatch.setattr(gh_mod, "is_available", lambda: True)
+
+        modals_seen: list[NewSessionModal] = []
+
+        async def fake_push_screen_wait(modal: Any) -> NewSessionResult | None:
+            assert isinstance(modal, NewSessionModal)
+            modals_seen.append(modal)
+            # Cancel the flow so we don't have to stub create_session.
+            return None
+
+        monkeypatch.setattr(app, "push_screen_wait", fake_push_screen_wait)
+
+        await app._new_session_flow()
+
+        assert list_calls == []
+        assert len(modals_seen) == 1
+        # The modal received no issues ⇒ picker hidden.
+        assert not modals_seen[0]._has_issue_picker
+
+
+async def test_new_session_flow_gh_unavailable_skips_list(monkeypatch):
+    """Repo detected but ``gh`` missing ⇒ list_issues not called, picker hidden."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        monkeypatch.setattr("chud.app.detect_cwd_repo", lambda: Path("/fake/repo"))
+        monkeypatch.setattr(gh_mod, "is_available", lambda: False)
+
+        list_calls: list[Path] = []
+
+        async def fake_list_issues(repo, **_kw):
+            list_calls.append(repo)
+            return []
+
+        monkeypatch.setattr(gh_mod, "list_issues", fake_list_issues)
+
+        modals_seen: list[NewSessionModal] = []
+
+        async def fake_push_screen_wait(modal: Any) -> NewSessionResult | None:
+            assert isinstance(modal, NewSessionModal)
+            modals_seen.append(modal)
+            return None
+
+        monkeypatch.setattr(app, "push_screen_wait", fake_push_screen_wait)
+
+        await app._new_session_flow()
+
+        assert list_calls == []
+        assert len(modals_seen) == 1
+        assert not modals_seen[0]._has_issue_picker

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -160,6 +160,77 @@ async def test_list_issues_returns_empty_on_empty_stdout(monkeypatch):
     assert await list_issues(Path("/r")) == []
 
 
+async def test_list_issue_numbers_with_open_pr_parses_graphql(monkeypatch):
+    """The GraphQL response collapses to the flat set of issue numbers any
+    open PR would close. Multiple PRs that reference the same issue
+    coalesce; PRs with no closing references are skipped."""
+    repo_view = json.dumps({"owner": {"login": "x"}, "name": "y"})
+    graphql = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "nodes": [
+                            {
+                                "closingIssuesReferences": {
+                                    "nodes": [{"number": 1}, {"number": 2}],
+                                },
+                            },
+                            {
+                                "closingIssuesReferences": {
+                                    "nodes": [{"number": 1}, {"number": 3}],
+                                },
+                            },
+                            {"closingIssuesReferences": {"nodes": []}},
+                        ],
+                    },
+                },
+            },
+        }
+    )
+
+    calls: list[list[str]] = []
+
+    async def fake_run(
+        cmd: list[str],
+        cwd: Path | None = None,
+        *,
+        timeout: float = 0.0,
+    ) -> tuple[int, str, str]:
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "repo", "view"]:
+            return 0, repo_view, ""
+        if cmd[:3] == ["gh", "api", "graphql"]:
+            return 0, graphql, ""
+        return 1, "", "unexpected command"
+
+    monkeypatch.setattr(gh_mod, "_run", fake_run)
+    nums = await gh_mod.list_issue_numbers_with_open_pr(Path("/r"))
+    assert nums == {1, 2, 3}
+    assert calls[0][:3] == ["gh", "repo", "view"]
+    assert calls[1][:3] == ["gh", "api", "graphql"]
+
+
+async def test_list_issue_numbers_with_open_pr_returns_empty_on_repo_view_failure(
+    monkeypatch,
+):
+    """If ``gh repo view`` can't resolve owner/name, skip GraphQL and
+    return an empty set — picker stays unfiltered rather than empty."""
+
+    async def fake_run(
+        cmd: list[str],
+        cwd: Path | None = None,
+        *,
+        timeout: float = 0.0,
+    ) -> tuple[int, str, str]:
+        if cmd[:3] == ["gh", "repo", "view"]:
+            return 1, "", "no remote"
+        raise AssertionError(f"graphql should not be invoked, got {cmd}")
+
+    monkeypatch.setattr(gh_mod, "_run", fake_run)
+    assert await gh_mod.list_issue_numbers_with_open_pr(Path("/r")) == set()
+
+
 async def test_list_issues_skips_malformed_items(monkeypatch):
     """Items missing required keys are dropped, well-formed ones survive."""
     payload = [

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -1,0 +1,201 @@
+"""Tests for ``chud.gh`` — the issue picker and shared subprocess plumbing.
+
+The pure ``build_issue_prompt`` formatter is exercised directly. The
+``list_issues`` async path is tested by monkeypatching ``chud.gh._run`` so
+no real ``gh`` subprocess is spawned — these tests must run on machines
+without GitHub CLI installed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chud import gh as gh_mod
+from chud.gh import Issue, build_issue_prompt, list_issues
+
+# --- build_issue_prompt --------------------------------------------------------
+
+
+def _issue(
+    *,
+    number: int = 42,
+    title: str = "Fix race in worker",
+    url: str = "https://github.com/x/y/issues/42",
+    body: str = "Repro: kick off two workers and watch the dispatch loop.",
+    state: str = "OPEN",
+) -> Issue:
+    return Issue(number=number, title=title, url=url, body=body, state=state)
+
+
+def test_build_issue_prompt_includes_all_sections():
+    out = build_issue_prompt(_issue(), "please fix")
+    # Header is the first non-empty block.
+    assert out.startswith("GitHub issue #42: Fix race in worker\n")
+    assert "https://github.com/x/y/issues/42" in out
+    # Body and user prompt are separated by ``---``.
+    assert "Repro:" in out
+    assert "\n---\n" in out
+    # User-typed prompt closes the message.
+    assert out.rstrip().endswith("please fix")
+
+
+def test_build_issue_prompt_truncates_long_body():
+    # Use 'Q' — guaranteed not to appear anywhere in the issue/url/prompt
+    # boilerplate so we can count body chars unambiguously.
+    long_body = "Q" * 9000
+    out = build_issue_prompt(_issue(body=long_body), "fix it")
+    assert "…(truncated)…" in out
+    # Exactly 8000 body chars survive — the rest are dropped.
+    assert out.count("Q") == 8000
+    # The marker appears immediately after the truncated body.
+    marker_idx = out.index("…(truncated)…")
+    assert out[marker_idx - 3 : marker_idx] == "Q\n\n"
+
+
+def test_build_issue_prompt_omits_blank_body():
+    out = build_issue_prompt(_issue(body="   \n\n  "), "do the work")
+    # No "Repro" sentinel, no leading blank-line-then-marker before ---.
+    assert "Repro" not in out
+    # Header → blank line → ---. Body block must not appear.
+    lines = out.split("\n")
+    # The very next non-empty block after the URL should be "---".
+    assert "---" in lines
+    sep_idx = lines.index("---")
+    # Everything from the URL to "---" should be just empty padding (one blank line).
+    assert all(line == "" for line in lines[2:sep_idx])
+    assert "do the work" in out
+
+
+def test_build_issue_prompt_strips_user_prompt_whitespace():
+    out = build_issue_prompt(_issue(body="b"), "  spaced prompt  \n")
+    assert out.endswith("spaced prompt")
+
+
+def test_build_issue_prompt_handles_crlf_in_body():
+    # CRLF normalization happens at parse time in ``list_issues``, but the
+    # prompt builder should also pass through clean LF bodies unchanged.
+    out = build_issue_prompt(_issue(body="line1\nline2"), "x")
+    assert "line1\nline2" in out
+
+
+# --- is_available --------------------------------------------------------------
+
+
+def test_is_available_reflects_path(monkeypatch):
+    monkeypatch.setattr(
+        gh_mod.shutil, "which", lambda name: "/usr/bin/gh" if name == "gh" else None
+    )
+    assert gh_mod.is_available() is True
+    monkeypatch.setattr(gh_mod.shutil, "which", lambda _name: None)
+    assert gh_mod.is_available() is False
+
+
+# --- list_issues ---------------------------------------------------------------
+
+
+def _stub_run(monkeypatch: pytest.MonkeyPatch, *, rc: int, stdout: str, stderr: str = "") -> None:
+    """Replace ``gh._run`` with a deterministic async stub."""
+
+    async def fake_run(
+        cmd: list[str],
+        cwd: Path | None = None,
+        *,
+        timeout: float = 0.0,
+    ) -> tuple[int, str, str]:
+        return rc, stdout, stderr
+
+    monkeypatch.setattr(gh_mod, "_run", fake_run)
+
+
+async def test_list_issues_parses_gh_json(monkeypatch):
+    payload: list[dict[str, Any]] = [
+        {
+            "number": 1,
+            "title": "Tighten retries",
+            "url": "https://github.com/x/y/issues/1",
+            "body": "first line\r\nsecond line",
+            "state": "OPEN",
+        },
+        {
+            "number": 2,
+            "title": "Add docs",
+            "url": "https://github.com/x/y/issues/2",
+            "body": "",
+            "state": "OPEN",
+        },
+    ]
+    _stub_run(monkeypatch, rc=0, stdout=json.dumps(payload))
+
+    issues = await list_issues(Path("/some/repo"))
+
+    assert len(issues) == 2
+    assert issues[0].number == 1
+    assert issues[0].title == "Tighten retries"
+    # CRLF normalized to LF.
+    assert issues[0].body == "first line\nsecond line"
+    assert issues[1].body == ""
+
+
+async def test_list_issues_returns_empty_on_nonzero_exit(monkeypatch):
+    _stub_run(monkeypatch, rc=1, stdout="", stderr="auth required")
+    assert await list_issues(Path("/r")) == []
+
+
+async def test_list_issues_returns_empty_on_invalid_json(monkeypatch):
+    _stub_run(monkeypatch, rc=0, stdout="not json")
+    assert await list_issues(Path("/r")) == []
+
+
+async def test_list_issues_returns_empty_on_non_list_json(monkeypatch):
+    _stub_run(monkeypatch, rc=0, stdout=json.dumps({"unexpected": "object"}))
+    assert await list_issues(Path("/r")) == []
+
+
+async def test_list_issues_returns_empty_on_empty_stdout(monkeypatch):
+    _stub_run(monkeypatch, rc=0, stdout="")
+    assert await list_issues(Path("/r")) == []
+
+
+async def test_list_issues_skips_malformed_items(monkeypatch):
+    """Items missing required keys are dropped, well-formed ones survive."""
+    payload = [
+        {"number": "not-an-int", "title": "x", "url": "u", "body": "", "state": "OPEN"},
+        {"number": 7, "title": "good", "url": "u", "body": "b", "state": "OPEN"},
+        {"missing_keys": True},
+    ]
+    _stub_run(monkeypatch, rc=0, stdout=json.dumps(payload))
+    issues = await list_issues(Path("/r"))
+    assert len(issues) == 1
+    assert issues[0].number == 7
+
+
+async def test_list_issues_passes_limit_and_cwd(monkeypatch):
+    """Verify the gh invocation includes --limit and is run with cwd=repo_path."""
+    seen: dict[str, Any] = {}
+
+    async def fake_run(
+        cmd: list[str],
+        cwd: Path | None = None,
+        *,
+        timeout: float = 0.0,
+    ) -> tuple[int, str, str]:
+        seen["cmd"] = cmd
+        seen["cwd"] = cwd
+        seen["timeout"] = timeout
+        return 0, "[]", ""
+
+    monkeypatch.setattr(gh_mod, "_run", fake_run)
+    await list_issues(Path("/repo/x"), limit=5, timeout=2.5)
+
+    assert seen["cwd"] == Path("/repo/x")
+    assert seen["timeout"] == 2.5
+    cmd = seen["cmd"]
+    assert cmd[0] == "gh"
+    assert "--limit" in cmd
+    assert cmd[cmd.index("--limit") + 1] == "5"
+    assert "--state" in cmd
+    assert cmd[cmd.index("--state") + 1] == "open"

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -152,6 +152,27 @@ def test_pick_body_uses_configured_footer_template(monkeypatch):
     assert "*Draft PR opened by chud session" not in body
 
 
+def test_pick_body_prepends_closes_when_issue_linked():
+    """``Closes #N`` lands at the top of the body when the session is linked
+    to a GitHub issue. This tells GitHub to wire up the Development sidebar
+    so the issue is filtered from the new-session picker on subsequent opens.
+    """
+    plan = "# Title\n\n## Context\n\nReasons.\n"
+    s = _state_with_one_repo(approved_plan=plan)
+    s.issue_number = 42
+    body = pr_mod.pick_body(s)
+    assert body.startswith("Closes #42\n\n")
+
+
+def test_pick_body_omits_closes_when_no_issue_linked():
+    """No issue → no ``Closes`` line; body is unchanged from the legacy shape."""
+    plan = "# Title\n\n## Context\n\nReasons.\n"
+    s = _state_with_one_repo(approved_plan=plan)
+    body = pr_mod.pick_body(s)
+    assert not body.startswith("Closes #")
+    assert body.startswith("Reasons.")
+
+
 def test_body_from_prompt_uses_configured_footer_template(monkeypatch):
     monkeypatch.setattr(pr_mod, "render_pr_body_footer", lambda sid: f"FOOTER[{sid}]")
     body = pr_mod._body_from_prompt("xyz", "do the thing")

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -141,3 +141,30 @@ def test_legacy_session_without_approved_plan_loads_as_none():
     }
     s = SessionState.from_dict(legacy)
     assert s.approved_plan is None
+
+
+def test_session_state_roundtrips_issue_number():
+    s = SessionState(
+        id="abc123",
+        workspace_dir=Path("/tmp/chud-ws/abc123"),
+        issue_number=42,
+    )
+    d = s.to_dict()
+    assert d["issue_number"] == 42
+    assert SessionState.from_dict(d).issue_number == 42
+
+
+def test_session_state_defaults_issue_number_to_none_when_absent():
+    legacy = {
+        "id": "old123",
+        "workspace_dir": "/tmp/old",
+        "status": "new",
+        "initial_prompt": "legacy",
+        "attached_repos": {},
+        "created_at": datetime.now(UTC).isoformat(),
+        "last_activity_at": datetime.now(UTC).isoformat(),
+        "pending_question": None,
+        "error": None,
+        # no "issue_number" key
+    }
+    assert SessionState.from_dict(legacy).issue_number is None


### PR DESCRIPTION
When kicking off a new chud session, the user often wants the agent to "go work on issue #42." Today they have to copy the title/body into the prompt by hand. We want the new-session modal (key `n`) to optionally pull a GitHub issue and fold it into the agent's initial prompt. When chud is launched inside a git repo, the picker shows that repo's recent open issues; outside a repo (or when `gh` is missing/unauthenticated), the modal renders exactly as it does today — silent degrade.

User-confirmed decisions:

- **UX:** dropdown of recent open issues only (no manual issue-number text field for now).
- **Prompt template:** issue title + URL + body get prepended to the user's typed prompt with a `---` separator.
- **`gh` missing/unauth:** hide the picker silently, log to `chud.log`.

---
PR made using [chud](https://github.com/Nixotica/chud).
