### PR TITLE
fix: prevent PRs containing other sessions' code

### DIFF
--- a/src/chud/pr.py
+++ b/src/chud/pr.py
@@ -73,6 +73,7 @@ async def _default_branch(repo_path: Path) -> str:
         return out
     return "main"
 
+
 async def _is_dirty(worktree: Path) -> bool:
     """Return True iff ``worktree`` has any tracked changes or untracked files.
 

--- a/src/chud/pr.py
+++ b/src/chud/pr.py
@@ -73,7 +73,6 @@ async def _default_branch(repo_path: Path) -> str:
         return out
     return "main"
 
-
 async def _is_dirty(worktree: Path) -> bool:
     """Return True iff ``worktree`` has any tracked changes or untracked files.
 

--- a/src/chud/pr.py
+++ b/src/chud/pr.py
@@ -51,7 +51,14 @@ class PRResult:
 
 
 async def _default_branch(repo_path: Path) -> str:
-    """Resolve the remote's default branch; fall back to ``main``."""
+    """Resolve the remote's default branch; fall back to ``main``.
+
+    Mirrors ``worktree.default_base_branch`` (sync version) so the publish
+    path and the worktree-create path agree on the answer. The async copy
+    here exists because every other subprocess call in this module routes
+    through ``_run`` (which tests monkeypatch); using a sync helper would
+    bypass the test harness.
+    """
     rc, out, _ = await _run(
         ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
         cwd=repo_path,
@@ -247,6 +254,25 @@ async def publish_draft_prs(
                         error=f"auto-commit failed: {err}",
                     )
                 )
+                continue
+
+        # Session-authorship gate. ``start_head`` is the worktree HEAD
+        # captured by ``WorktreeManager.attach_repo`` *before* the agent
+        # runs, so ``rev-list start_head..HEAD`` counts only commits that
+        # this session produced. If a contaminated branch base means the
+        # branch carries other sessions' commits but none of our own, the
+        # ``origin/<base>..HEAD`` check below would still see those foreign
+        # commits and proceed to publish a misleading PR — this gate stops
+        # that. Skipped for legacy worktrees persisted before the field
+        # existed (``start_head is None``); in that case the existing
+        # ``origin/<base>..HEAD`` check is the only line of defense.
+        if wt.start_head:
+            rc, count, err = await _run(
+                ["git", "rev-list", "--count", f"{wt.start_head}..HEAD"],
+                cwd=worktree,
+            )
+            if rc == 0 and count.strip() == "0":
+                results.append(PRResult(repo_label=label, branch=branch, discarded=True))
                 continue
 
         # Refresh ``origin/{base}`` before counting commits ahead. Without this,

--- a/src/chud/types.py
+++ b/src/chud/types.py
@@ -9,6 +9,7 @@ from typing import Any
 KEY_REPO_PATH = "repo_path"
 KEY_WORKTREE_PATH = "worktree_path"
 KEY_BRANCH = "branch"
+KEY_START_HEAD = "start_head"
 
 KEY_ID = "id"
 KEY_STATUS = "status"
@@ -39,12 +40,18 @@ class Worktree:
     repo_path: Path
     worktree_path: Path
     branch: str
+    # Worktree HEAD oid captured at creation time. The PR-publish path uses
+    # this as the lower bound for "did this session contribute commits?", so
+    # a session whose branch only carries unrelated commits inherited from a
+    # contaminated parent HEAD doesn't get a draft PR opened against it.
+    start_head: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
             KEY_REPO_PATH: str(self.repo_path),
             KEY_WORKTREE_PATH: str(self.worktree_path),
             KEY_BRANCH: self.branch,
+            KEY_START_HEAD: self.start_head,
         }
 
     @classmethod
@@ -53,6 +60,7 @@ class Worktree:
             repo_path=Path(d[KEY_REPO_PATH]),
             worktree_path=Path(d[KEY_WORKTREE_PATH]),
             branch=d[KEY_BRANCH],
+            start_head=d.get(KEY_START_HEAD),
         )
 
 

--- a/src/chud/types.py
+++ b/src/chud/types.py
@@ -40,10 +40,6 @@ class Worktree:
     repo_path: Path
     worktree_path: Path
     branch: str
-    # Worktree HEAD oid captured at creation time. The PR-publish path uses
-    # this as the lower bound for "did this session contribute commits?", so
-    # a session whose branch only carries unrelated commits inherited from a
-    # contaminated parent HEAD doesn't get a draft PR opened against it.
     start_head: str | None = None
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/chud/worktree.py
+++ b/src/chud/worktree.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -65,6 +66,56 @@ def repo_toplevel(path: Path) -> Path:
         check=True,
     )
     return Path(result.stdout.strip())
+
+
+def default_base_branch(repo_path: Path) -> str:
+    """Resolve the remote's default branch name (e.g. ``main``, ``master``).
+
+    Order of preference:
+
+    1. ``git symbolic-ref --short refs/remotes/origin/HEAD`` — the canonical
+       answer when the clone has been initialized with a remote HEAD.
+    2. ``gh repo view --json defaultBranchRef`` — covers the case where the
+       symbolic-ref isn't set locally but ``gh`` is on PATH and authed.
+    3. ``"main"`` — last-resort fallback so callers always get a string.
+
+    The returned name is *unqualified* (``main``, not ``origin/main``); callers
+    decide whether to look it up under ``refs/remotes/origin/`` or
+    ``refs/heads/``.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo_path), "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        out = result.stdout.strip()
+        if "/" in out:
+            return out.split("/", 1)[1]
+
+    if shutil.which("gh") is not None:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "defaultBranchRef", "-q", ".defaultBranchRef.name"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_path),
+        )
+        if result.returncode == 0:
+            out = result.stdout.strip()
+            if out:
+                return out
+
+    return "main"
+
+
+def _ref_exists(repo_path: Path, ref: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "--verify", ref],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
 
 
 def detect_cwd_repo() -> Path | None:
@@ -142,17 +193,82 @@ class WorktreeManager:
 
         cmd = ["git", "-C", str(toplevel), "worktree", "add"]
         if branch_exists:
+            # Re-attach: never silently rewrite an existing chud branch — that
+            # would clobber a previous session's in-progress work. Just check
+            # the branch out at its current tip.
             cmd += [str(worktree_path), branch]
         else:
-            cmd += [str(worktree_path), "-b", branch]
+            base_ref = self._resolve_clean_base_ref(toplevel)
+            cmd += [str(worktree_path), "-b", branch, base_ref]
 
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
             raise WorktreeError(f"git worktree add failed for {toplevel}: {result.stderr.strip()}")
 
-        wt = Worktree(repo_path=toplevel, worktree_path=worktree_path, branch=branch)
+        start_head = self._capture_head(worktree_path)
+        wt = Worktree(
+            repo_path=toplevel,
+            worktree_path=worktree_path,
+            branch=branch,
+            start_head=start_head,
+        )
         self.session.attached_repos[repo_key] = wt
         return wt
+
+    @staticmethod
+    def _resolve_clean_base_ref(toplevel: Path) -> str:
+        """Pick a clean upstream ref to fork a new chud branch from.
+
+        Forking from the parent repo's local ``HEAD`` (``git worktree add -b``
+        without a base) silently inherits whatever branch the user — or
+        another concurrent chud session — happens to have checked out, which
+        is how unrelated WIP commits leak into a fresh session's PR. Instead:
+
+        1. Resolve the remote's default branch (``main``/``master``/...).
+        2. Best-effort ``git fetch origin <base>`` — refreshes the remote ref
+           so we fork from current upstream tip, not whatever stale ref the
+           local clone last saw. Offline/auth failures are logged and the
+           fetch is skipped; we fall through to whichever ref exists locally.
+        3. Prefer ``origin/<base>``; fall back to local ``<base>`` if the
+           remote ref is unavailable; raise ``WorktreeError`` if neither
+           exists. A hard error here beats opening a contaminated PR later —
+           unusual repos (no main/master at all) are rare enough to deserve
+           the explicit failure.
+        """
+        base = default_base_branch(toplevel)
+
+        fetch = subprocess.run(
+            ["git", "-C", str(toplevel), "fetch", "origin", base],
+            capture_output=True,
+            text=True,
+        )
+        if fetch.returncode != 0:
+            log.warning(
+                "git fetch origin %s failed in %s: %s",
+                base,
+                toplevel,
+                fetch.stderr.strip(),
+            )
+
+        if _ref_exists(toplevel, f"refs/remotes/origin/{base}"):
+            return f"origin/{base}"
+        if _ref_exists(toplevel, f"refs/heads/{base}"):
+            return base
+        raise WorktreeError(
+            f"could not resolve a base ref for new chud branch in {toplevel}: "
+            f"no origin/{base} and no local {base}"
+        )
+
+    @staticmethod
+    def _capture_head(worktree_path: Path) -> str | None:
+        result = subprocess.run(
+            ["git", "-C", str(worktree_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip() or None
 
     def detach_repo(self, repo_key: str, force: bool = False) -> None:
         wt = self.session.attached_repos.get(repo_key)

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -502,3 +502,144 @@ async def test_publish_continues_when_fetch_fails(monkeypatch):
     results = await pr_mod.publish_draft_prs(_state_with_one_repo())
     assert results[0].error is None
     assert results[0].url == "https://github.com/x/y/pull/10"
+
+
+# --- session-authorship gate (Bug 2 fix) -------------------------------------
+
+_SESSION_START_OID = "abc123abc123abc123abc123abc123abc123abc1"
+
+
+def _state_with_start_head(start_head: str | None) -> SessionState:
+    s = SessionState(id="sess1", initial_prompt="add a foo")
+    s.attached_repos["myrepo"] = Worktree(
+        repo_path=Path("/tmp/myrepo"),
+        worktree_path=Path("/tmp/chud-wt/sess1-myrepo"),
+        branch="chud/add-a-foo-sess1",
+        start_head=start_head,
+    )
+    return s
+
+
+@pytest.mark.asyncio
+async def test_publish_skips_when_no_session_authored_commits(monkeypatch):
+    """Reproducer for PR #51 contamination at the publish layer.
+
+    Even when the branch has commits ahead of ``origin/main`` (the existing
+    abandonment check passes), if none of those commits were authored *by
+    this session* (i.e. ``start_head..HEAD`` is empty) the PR must be
+    discarded silently — never opened with the session's plan as title."""
+    monkeypatch.setattr(pr_mod.shutil, "which", lambda _: "/usr/bin/gh")
+
+    calls: list[list[str]] = []
+
+    async def fake_run(cmd, cwd=None):
+        calls.append(cmd)
+        if cmd[:2] == ["git", "symbolic-ref"]:
+            return 0, "origin/main", ""
+        if cmd[:2] == ["git", "fetch"]:
+            return 0, "", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, "", ""  # clean
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            # The session-authorship gate checks ``start_head..HEAD``;
+            # any other rev-list (e.g. origin/main..HEAD) would still see
+            # foreign commits and proceed to publish if the gate didn't fire.
+            if any(arg.startswith(_SESSION_START_OID) for arg in cmd):
+                return 0, "0", ""
+            return 0, "8", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(pr_mod, "_run", fake_run)
+
+    results = await pr_mod.publish_draft_prs(_state_with_start_head(_SESSION_START_OID))
+    assert len(results) == 1
+    assert results[0].discarded is True
+    assert results[0].url is None
+    assert results[0].error is None
+    # No push, no PR open.
+    assert not any(c[:2] == ["git", "push"] for c in calls)
+    assert not any(c[:1] == ["gh"] for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_publish_proceeds_when_session_authored_commits_exist(monkeypatch):
+    """Gate passes (≥1 commit since ``start_head``) → normal publish flow."""
+    monkeypatch.setattr(pr_mod.shutil, "which", lambda _: "/usr/bin/gh")
+
+    async def fake_run(cmd, cwd=None):
+        if cmd[:2] == ["git", "symbolic-ref"]:
+            return 0, "origin/main", ""
+        if cmd[:2] == ["git", "fetch"]:
+            return 0, "", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, "", ""
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return 0, "1", ""
+        if cmd[:3] == ["git", "push", "-u"]:
+            return 0, "", ""
+        if cmd[:1] == ["gh"]:
+            return 0, "https://github.com/x/y/pull/11", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(pr_mod, "_run", fake_run)
+
+    results = await pr_mod.publish_draft_prs(_state_with_start_head(_SESSION_START_OID))
+    assert results[0].error is None
+    assert results[0].url == "https://github.com/x/y/pull/11"
+    assert results[0].discarded is False
+
+
+@pytest.mark.asyncio
+async def test_publish_falls_back_to_origin_count_when_start_head_missing(monkeypatch):
+    """Legacy ``Worktree`` (start_head=None) → gate is skipped, existing
+    ``origin/<base>..HEAD`` check is the only line of defense."""
+    monkeypatch.setattr(pr_mod.shutil, "which", lambda _: "/usr/bin/gh")
+
+    rev_list_args: list[list[str]] = []
+
+    async def fake_run(cmd, cwd=None):
+        if cmd[:2] == ["git", "symbolic-ref"]:
+            return 0, "origin/main", ""
+        if cmd[:2] == ["git", "fetch"]:
+            return 0, "", ""
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return 0, "", ""
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            rev_list_args.append(cmd)
+            return 0, "0", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(pr_mod, "_run", fake_run)
+
+    results = await pr_mod.publish_draft_prs(_state_with_start_head(None))
+    assert results[0].discarded is True
+    # Exactly one rev-list — the legacy origin/main..HEAD check, not the
+    # new gate (which is skipped because start_head is None).
+    assert len(rev_list_args) == 1
+    assert rev_list_args[0][-1] == "origin/main..HEAD"
+
+
+# --- Worktree.start_head round-trip ------------------------------------------
+
+
+def test_worktree_round_trip_with_start_head():
+    wt = Worktree(
+        repo_path=Path("/tmp/r"),
+        worktree_path=Path("/tmp/wt"),
+        branch="chud/x-sess1",
+        start_head="deadbeef" * 5,
+    )
+    assert Worktree.from_dict(wt.to_dict()) == wt
+
+
+def test_worktree_from_dict_legacy_without_start_head():
+    """Persistence layer must tolerate sessions.json entries written before
+    the field existed — they default ``start_head`` to None."""
+    legacy = {
+        "repo_path": "/tmp/r",
+        "worktree_path": "/tmp/wt",
+        "branch": "chud/x-sess1",
+    }
+    wt = Worktree.from_dict(legacy)
+    assert wt.start_head is None
+    assert wt.branch == "chud/x-sess1"

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -39,6 +39,47 @@ def _init_repo(path: Path) -> None:
     )
 
 
+def _init_repo_with_origin(repo: Path, bare: Path) -> None:
+    """Init ``repo`` as a clone-of-``bare`` style setup with one commit on main.
+
+    The bare repo at ``bare`` plays the role of a remote (``origin``); the
+    local ``repo`` has it configured as ``origin``, has a local ``main``
+    pushed, and ``origin/HEAD`` set so ``default_base_branch`` resolves
+    cleanly. The result is the closest analog to a real cloned repo we can
+    build without network.
+    """
+    bare.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(bare)], check=True, capture_output=True
+    )
+    _init_repo(repo)
+    subprocess.run(
+        ["git", "-C", str(repo), "remote", "add", "origin", str(bare)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "push", "-u", "origin", "main"], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "remote", "set-head", "origin", "main"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _commit(repo: Path, filename: str, contents: str, message: str) -> str:
+    (repo / filename).write_text(contents)
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", message], check=True, capture_output=True
+    )
+    out = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    )
+    return out.stdout.strip()
+
+
 def test_is_git_repo(tmp_path: Path):
     assert not is_git_repo(tmp_path)
     _init_repo(tmp_path)
@@ -274,3 +315,123 @@ def test_slugify_truncates_at_hyphen_boundary():
     assert not out.endswith("-")
     # Should end on a complete word boundary, not mid-word.
     assert all(part for part in out.split("-"))
+
+
+def test_attach_repo_forks_from_origin_default_not_local_head(tmp_path: Path):
+    """Reproducer for PR #51 contamination.
+
+    Setup: a clone-of-origin where origin/main is at commit A, but the
+    parent repo's local HEAD has been advanced to commit B (simulating a
+    user who switched branches or a concurrent chud session that left WIP
+    on top). The new chud branch must fork from ``origin/main`` (commit A),
+    *not* the parent repo's current ``HEAD`` (commit B), so commit B's
+    contents do not leak into the new branch.
+    """
+    repo = tmp_path / "myrepo"
+    bare = tmp_path / "myrepo-bare.git"
+    _init_repo_with_origin(repo, bare)
+    a_oid = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    # Advance the parent repo's local HEAD past origin/main with a "WIP"
+    # commit that hasn't been pushed.
+    subprocess.run(
+        ["git", "-C", str(repo), "checkout", "-b", "wip-other-session"],
+        check=True,
+        capture_output=True,
+    )
+    b_oid = _commit(repo, "leaked.txt", "do not leak me", "wip from another session")
+    assert a_oid != b_oid
+
+    session = SessionState(id="sess1", initial_prompt="add foo")
+    mgr = WorktreeManager(session)
+    wt = mgr.attach_repo(repo)
+
+    head = subprocess.run(
+        ["git", "-C", str(wt.worktree_path), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert head == a_oid, "new chud branch must fork from origin/main, not local HEAD"
+    assert not (wt.worktree_path / "leaked.txt").exists()
+
+
+def test_attach_repo_records_start_head(tmp_path: Path):
+    repo = tmp_path / "myrepo"
+    _init_repo(repo)
+    session = SessionState(id="sess1", initial_prompt="add foo")
+    mgr = WorktreeManager(session)
+
+    wt = mgr.attach_repo(repo)
+
+    expected = subprocess.run(
+        ["git", "-C", str(wt.worktree_path), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert wt.start_head is not None
+    assert wt.start_head == expected
+    assert len(wt.start_head) == 40  # full sha, not abbreviated
+
+
+def test_attach_repo_falls_back_to_local_main_without_origin(tmp_path: Path):
+    """Repo with no ``origin`` remote forks from local ``main``."""
+    repo = tmp_path / "myrepo"
+    _init_repo(repo)
+    session = SessionState(id="sess1", initial_prompt="add foo")
+    mgr = WorktreeManager(session)
+
+    wt = mgr.attach_repo(repo)
+
+    main_tip = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "main"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert wt.start_head == main_tip
+
+
+def test_attach_repo_raises_when_no_base_branch_exists(tmp_path: Path):
+    """Repo whose default-branch resolution lands on a non-existent ref → hard fail."""
+    repo = tmp_path / "weirdrepo"
+    repo.mkdir(parents=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "init", "-b", "develop"], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "t@t"], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "t"], check=True, capture_output=True
+    )
+    (repo / "README").write_text("hi")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True
+    )
+    # No origin, no local "main" or "master" — only "develop" exists.
+    # default_base_branch falls back to "main", which doesn't exist anywhere.
+    session = SessionState(id="sess1", initial_prompt="add foo")
+    mgr = WorktreeManager(session)
+
+    with pytest.raises(WorktreeError, match="could not resolve a base ref"):
+        mgr.attach_repo(repo)
+
+
+def test_attach_repo_reattach_unchanged(tmp_path: Path):
+    """Re-attaching the same repo yields the same Worktree, including ``start_head``."""
+    repo = tmp_path / "myrepo"
+    _init_repo(repo)
+    session = SessionState(id="sess1", initial_prompt="add foo")
+    mgr = WorktreeManager(session)
+
+    wt1 = mgr.attach_repo(repo)
+    wt2 = mgr.attach_repo(repo)
+
+    assert wt1 is wt2
+    assert wt1.start_head == wt2.start_head
+    assert wt1.start_head is not None


### PR DESCRIPTION
## Summary

Two complementary fixes for the PR #51 contamination failure (see `INVESTIGATION-pr51-contamination.md`), where chud auto-published a draft PR whose diff was entirely commits from three other in-flight sessions.

- **Worktree base contamination** (`src/chud/worktree.py`): `git worktree add -b <branch>` ran without a base ref, so new chud branches silently inherited whatever the parent repo's local HEAD pointed at. Now resolves the remote default branch (with `gh` fallback), best-effort `git fetch origin <base>`, then forks from `origin/<base>` (falls back to local `<base>`, raises `WorktreeError` if neither exists).
- **Auto-publish ignored session authorship** (`src/chud/pr.py`, `src/chud/types.py`): the existing "0 commits ahead of `origin/<base>`" gate doesn't fire when the branch carries foreign commits. Capture worktree HEAD at attach time as `Worktree.start_head` and gate `publish_draft_prs` on `rev-list start_head..HEAD == 0` → silent discard. Backwards-compatible: legacy entries with `start_head=None` fall through to the existing origin-count check.

## Test plan

- [x] `pytest` — 209 passed
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `pyright` — 0 errors
- [x] Manual: parent repo on a branch with WIP commits ahead of `origin/main`; new session forks from `origin/main` (reflog: `Created from origin/main`); session that makes zero edits emits `WORKTREE_DISCARDED`, no PR opened.
- [x] Manual: same setup with one real edit → PR opens with only that edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)