### PR TITLE
chore: Allow `j`/`k` (and `h`/`l`) for vim-style navigation

### DIFF
--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -10,8 +10,9 @@ from typing import Any, Literal
 
 from textual import on
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal
-from textual.widgets import Footer, Header, Input, ListView
+from textual.containers import Horizontal, ScrollableContainer
+from textual.widget import Widget
+from textual.widgets import Footer, Header, Input, ListView, RichLog
 
 from chud import gh as gh_mod
 from chud import state as state_mod
@@ -57,9 +58,15 @@ class ChudApp(App[None]):
 
     BINDINGS = [
         ("n", "new_session", "New session"),
-        ("k", "kill_session", "Kill session"),
+        ("x", "kill_session", "Kill session"),
         ("s", "settings", "Settings"),
         ("q", "quit", "Quit"),
+        # Vim-style scroll on the focused pane (transcript / session list).
+        # Textual won't deliver these to the app while a text input owns focus,
+        # so typing `j`/`k` into the message box still inserts the literal
+        # character.
+        ("j", "scroll_focus_down", "Scroll down"),
+        ("k", "scroll_focus_up", "Scroll up"),
     ]
 
     CSS = """
@@ -278,6 +285,35 @@ class ChudApp(App[None]):
         finally:
             self._user_modal_depth -= 1
             self._maybe_show_next_prompt()
+
+    def action_scroll_focus_down(self) -> None:
+        self._scroll_focused(down=True)
+
+    def action_scroll_focus_up(self) -> None:
+        self._scroll_focused(down=False)
+
+    def _scroll_focused(self, *, down: bool) -> None:
+        """Scroll the nearest scrollable ancestor of ``self.focused``.
+
+        For ``ListView`` we move the highlight (which auto-scrolls) so
+        ``j``/``k`` matches the existing arrow-key behaviour. For other
+        scrollables we just nudge ``scroll_y`` by one line.
+        """
+        target: Widget | None = self.focused
+        while target is not None:
+            if isinstance(target, ListView):
+                if down:
+                    target.action_cursor_down()
+                else:
+                    target.action_cursor_up()
+                return
+            if isinstance(target, RichLog | ScrollableContainer):
+                if down:
+                    target.scroll_down()
+                else:
+                    target.scroll_up()
+                return
+            target = target.parent if isinstance(target.parent, Widget) else None
 
     async def action_kill_session(self) -> None:
         sid = self._selected_session_id

--- a/src/chud/widgets/_scrollable_modal.py
+++ b/src/chud/widgets/_scrollable_modal.py
@@ -1,0 +1,50 @@
+"""Shared base for chud's modal screens.
+
+Adds vim-style ``j``/``k`` scroll bindings that route to a single
+``VerticalScroll`` exposed by the subclass via :py:meth:`scroll_container`.
+The bindings no-op while a text input owns focus, so the user can type
+literal ``j``/``k`` into prompts without scrolling the modal underneath.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Input, TextArea
+
+ScreenResultType = TypeVar("ScreenResultType")
+
+
+class ScrollableModalScreen(ModalScreen[ScreenResultType]):
+    """``ModalScreen`` base with vim-style j/k scroll over a single container.
+
+    Subclasses override :py:meth:`scroll_container` to return the
+    ``VerticalScroll`` (or any scrollable ``Widget`` exposing ``scroll_up`` /
+    ``scroll_down``) that should respond to ``j``/``k``.
+    """
+
+    BINDINGS = [
+        Binding("j", "vim_scroll_down", show=False),
+        Binding("k", "vim_scroll_up", show=False),
+    ]
+
+    def scroll_container(self) -> VerticalScroll | None:
+        """The scroll target for ``j``/``k``. Return ``None`` to disable."""
+        return None
+
+    def _vim_scroll(self, *, down: bool) -> None:
+        if isinstance(self.focused, Input | TextArea):
+            return
+        container = self.scroll_container()
+        if container is None:
+            return
+        (container.scroll_down if down else container.scroll_up)()
+
+    def action_vim_scroll_down(self) -> None:
+        self._vim_scroll(down=True)
+
+    def action_vim_scroll_up(self) -> None:
+        self._vim_scroll(down=False)

--- a/src/chud/widgets/cleanup_confirmation_modal.py
+++ b/src/chud/widgets/cleanup_confirmation_modal.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.screen import ModalScreen
 from textual.widgets import Button, Static
 
 from chud.types import SessionState
+from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 
-class CleanupConfirmationModal(ModalScreen[bool]):
+class CleanupConfirmationModal(ScrollableModalScreen[bool]):
     """Confirm cleanup of a finished session.
 
     Two visual modes, selected by ``published_prs``:
@@ -71,6 +71,12 @@ class CleanupConfirmationModal(ModalScreen[bool]):
         super().__init__()
         self.state = state
         self.published_prs = list(published_prs or [])
+
+    def scroll_container(self) -> VerticalScroll | None:
+        try:
+            return self.query_one(VerticalScroll)
+        except Exception:
+            return None
 
     def compose(self) -> ComposeResult:
         with Vertical():

--- a/src/chud/widgets/new_session_modal.py
+++ b/src/chud/widgets/new_session_modal.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Label, Select, Static, TextArea
 
 from chud.gh import Issue, build_issue_prompt
@@ -18,6 +17,7 @@ from chud.state import (
     user_default_options,
 )
 from chud.types import KEY_EFFORT
+from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 _EFFORT_CHOICES: tuple[tuple[str, str], ...] = tuple((v.capitalize(), v) for v in EFFORT_VALUES)
 
@@ -36,7 +36,7 @@ class NewSessionResult:
     issue: Issue | None = None
 
 
-class NewSessionModal(ModalScreen[NewSessionResult | None]):
+class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
     """Prompt the user for an initial prompt + options for a new session.
 
     The repo to attach is derived automatically from chud's launch directory
@@ -170,6 +170,12 @@ class NewSessionModal(ModalScreen[NewSessionResult | None]):
         if len(active) == 1:
             return f"{ACTIVE_CHUD_ICON} {base}"
         return f"{ACTIVE_CHUD_ICON}×{len(active)} {base}"
+
+    def scroll_container(self) -> VerticalScroll | None:
+        try:
+            return self.query_one("#body", VerticalScroll)
+        except Exception:
+            return None
 
     def compose(self) -> ComposeResult:
         with Vertical():

--- a/src/chud/widgets/plan_modal.py
+++ b/src/chud/widgets/plan_modal.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Markdown, Static
 
+from chud.widgets._scrollable_modal import ScrollableModalScreen
 
-class PlanApprovalModal(ModalScreen[bool | str]):
+
+class PlanApprovalModal(ScrollableModalScreen[bool | str]):
     """Show the agent's proposed plan and gate execution on user approval.
 
     Returns:
@@ -67,6 +68,12 @@ class PlanApprovalModal(ModalScreen[bool | str]):
         super().__init__()
         self.session_id = session_id
         self.plan_text = plan_text
+
+    def scroll_container(self) -> VerticalScroll | None:
+        try:
+            return self.query_one(VerticalScroll)
+        except Exception:
+            return None
 
     def compose(self) -> ComposeResult:
         with Vertical():

--- a/src/chud/widgets/pr_review_modal.py
+++ b/src/chud/widgets/pr_review_modal.py
@@ -18,8 +18,9 @@ from dataclasses import dataclass
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Static, TextArea
+
+from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 
 @dataclass
@@ -29,7 +30,7 @@ class PRReviewResult:
     body: str
 
 
-class PRReviewModal(ModalScreen[PRReviewResult | None]):
+class PRReviewModal(ScrollableModalScreen[PRReviewResult | None]):
     """Show the proposed draft-PR title/body and gate publishing on approval.
 
     Returns:
@@ -100,6 +101,12 @@ class PRReviewModal(ModalScreen[PRReviewResult | None]):
         self._initial_title = title
         self._initial_body = body
         self._repos = list(repos)
+
+    def scroll_container(self) -> VerticalScroll | None:
+        try:
+            return self.query_one("#repos", VerticalScroll)
+        except Exception:
+            return None
 
     def compose(self) -> ComposeResult:
         with Vertical():

--- a/src/chud/widgets/question_modal.py
+++ b/src/chud/widgets/question_modal.py
@@ -482,7 +482,9 @@ class QuestionModal(ScrollableModalScreen[str | None]):
         Right/left expand/collapse the *focused* option (or the highlighted
         radio inside a focused RadioSet). Up/down moves between Checkboxes
         in the same multi-select question, falling through to adjacent
-        questions at the boundaries. Inputs keep their own cursor handling
+        questions at the boundaries. j/k mirror up/down for vim-style nav,
+        including inside a focused RadioSet (Textual's RadioSet only binds
+        up/down/left/right natively). Inputs keep their own cursor handling
         because we early-return on ``Input``-focused widgets.
         """
         focused = self.focused
@@ -525,6 +527,39 @@ class QuestionModal(ScrollableModalScreen[str | None]):
                         self.query_one(f"#q{q_idx}-opt{opt_idx - 1}", Checkbox).focus()
                 else:
                     self._retreat_to(q_idx)
+            return
+
+        if event.key in ("up", "down", "j", "k") and isinstance(focused, RadioSet):
+            # RadioSet binds up/down/left/right natively but not j/k, and at
+            # the first/last radio neither set crosses into the adjacent
+            # question. We fill both gaps here so single-select questions
+            # navigate identically to multi-select ones.
+            radios = [c for c in focused.children if isinstance(c, _CheckMarkRadio)]
+            if not radios:
+                return
+            selected = focused._selected if isinstance(focused._selected, int) else 0
+            going_down = event.key in ("down", "j")
+            at_boundary = (going_down and selected >= len(radios) - 1) or (
+                not going_down and selected <= 0
+            )
+            q_idx = self._question_index_of(focused)
+            if at_boundary and q_idx is not None:
+                event.stop()
+                event.prevent_default()
+                if going_down:
+                    self._advance_from(q_idx)
+                else:
+                    self._retreat_to(q_idx)
+                return
+            if event.key in ("j", "k"):
+                event.stop()
+                event.prevent_default()
+                with contextlib.suppress(Exception):
+                    if going_down:
+                        focused.action_next_button()
+                    else:
+                        focused.action_previous_button()
+                return
 
     def _submit(self) -> None:
         parts: list[str] = []

--- a/src/chud/widgets/question_modal.py
+++ b/src/chud/widgets/question_modal.py
@@ -10,10 +10,11 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.content import Content
 from textual.geometry import Size
-from textual.screen import ModalScreen
 from textual.style import Style
 from textual.widget import Widget
 from textual.widgets import Button, Checkbox, Input, RadioButton, RadioSet, Static
+
+from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 
 def _toggle_button_with_off_glyph(self: Checkbox | RadioButton, inner_off: str) -> Content:
@@ -179,7 +180,7 @@ class _CheckMarkRadio(_ExpandableOption, RadioButton):
         return _toggle_button_with_off_glyph(self, self.BUTTON_INNER_OFF)
 
 
-class QuestionModal(ModalScreen[str | None]):
+class QuestionModal(ScrollableModalScreen[str | None]):
     """Render an AskUserQuestion tool call and collect the user's answer."""
 
     DEFAULT_CSS = """
@@ -291,6 +292,12 @@ class QuestionModal(ModalScreen[str | None]):
                     "_raw": json.dumps(question_input, default=str, indent=2),
                 }
             ]
+
+    def scroll_container(self) -> VerticalScroll | None:
+        try:
+            return self.query_one(VerticalScroll)
+        except Exception:
+            return None
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -482,18 +489,18 @@ class QuestionModal(ModalScreen[str | None]):
         if focused is None or isinstance(focused, Input):
             return
 
-        if event.key in ("right", "left"):
+        if event.key in ("right", "left", "l", "h"):
             target = self._focused_option()
             if target is None or not target.is_long:
                 return
-            expand = event.key == "right"
+            expand = event.key in ("right", "l")
             if target._expanded != expand:
                 target.set_expanded(expand)
                 event.stop()
                 event.prevent_default()
             return
 
-        if event.key in ("up", "down") and isinstance(focused, Checkbox):
+        if event.key in ("up", "down", "j", "k") and isinstance(focused, Checkbox):
             wid = focused.id or ""
             if "-opt" not in wid:
                 return
@@ -506,7 +513,7 @@ class QuestionModal(ModalScreen[str | None]):
             count = len(q.get("options") or [])
             event.stop()
             event.prevent_default()
-            if event.key == "down":
+            if event.key in ("down", "j"):
                 if opt_idx + 1 < count:
                     with contextlib.suppress(Exception):
                         self.query_one(f"#q{q_idx}-opt{opt_idx + 1}", Checkbox).focus()

--- a/src/chud/widgets/session_list.py
+++ b/src/chud/widgets/session_list.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from rich.text import Text
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.widgets import Label, ListItem, ListView
 
@@ -65,6 +66,17 @@ class SessionListView(VerticalScroll):
         padding: 0 1;
     }
     """
+
+    BINDINGS = [
+        Binding("j", "cursor_down", show=False),
+        Binding("k", "cursor_up", show=False),
+    ]
+
+    def action_cursor_down(self) -> None:
+        self.list_view.action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        self.list_view.action_cursor_up()
 
     def compose(self) -> ComposeResult:
         yield ListView(id="session-list")

--- a/src/chud/widgets/session_view.py
+++ b/src/chud/widgets/session_view.py
@@ -34,6 +34,8 @@ class SessionView(Vertical):
 
     BINDINGS = [
         Binding("escape", "focus_transcript", "Focus transcript", show=False),
+        Binding("j", "scroll_transcript_down", show=False),
+        Binding("k", "scroll_transcript_up", show=False),
     ]
 
     def compose(self) -> ComposeResult:
@@ -52,6 +54,12 @@ class SessionView(Vertical):
     @property
     def input(self) -> Input:
         return self.query_one("#input", Input)
+
+    def action_scroll_transcript_down(self) -> None:
+        self.transcript.scroll_down()
+
+    def action_scroll_transcript_up(self) -> None:
+        self.transcript.scroll_up()
 
     def action_focus_transcript(self) -> None:
         """Move focus from the input back up to the transcript.

--- a/src/chud/widgets/settings_modal.py
+++ b/src/chud/widgets/settings_modal.py
@@ -21,7 +21,6 @@ import contextlib
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Input, Label, Static, TextArea
 
 from chud.options import SESSION_OPTIONS
@@ -34,9 +33,10 @@ from chud.settings import (
     save_settings,
 )
 from chud.state import load_user_config, save_user_config, user_default_options
+from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 
-class SettingsModal(ModalScreen[bool]):
+class SettingsModal(ScrollableModalScreen[bool]):
     """Edit persistent chud preferences.
 
     Returns ``True`` if the user saved, ``False`` if cancelled / dismissed.
@@ -109,6 +109,12 @@ class SettingsModal(ModalScreen[bool]):
         Binding("escape", "cancel", "Cancel"),
         Binding("f2", "save", "Save", priority=True),
     ]
+
+    def scroll_container(self) -> VerticalScroll | None:
+        try:
+            return self.query_one("#scroll", VerticalScroll)
+        except Exception:
+            return None
 
     def compose(self) -> ComposeResult:
         snapshot = load_settings()

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -921,3 +921,125 @@ async def test_new_session_flow_gh_unavailable_skips_list(monkeypatch):
         assert list_calls == []
         assert len(modals_seen) == 1
         assert not modals_seen[0]._has_issue_picker
+
+
+# --- Vim-style scroll bindings (issue #50) -----------------------------------
+
+
+async def test_app_x_key_kills_selected_session(monkeypatch):
+    """`x` is the kill-session shortcut (rebound from `k` to free `k` for scroll)."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        called: list[str | None] = []
+
+        async def fake_kill(self) -> None:
+            called.append(self._selected_session_id)
+
+        monkeypatch.setattr(ChudApp, "action_kill_session", fake_kill, raising=True)
+        await pilot.press("x")
+        await pilot.pause()
+        assert called == [None]
+
+
+async def test_j_k_scroll_transcript_when_focused():
+    """`j`/`k` drive the transcript's scroll position when it owns focus."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        view = app.query_one(SessionView)
+        st = SessionState(id="scroll1", initial_prompt="p")
+        view.show_session(st)
+        # Pump enough lines to make the RichLog scrollable.
+        for i in range(200):
+            view.transcript.write(f"line {i}")
+        await pilot.pause()
+        view.transcript.focus()
+        await pilot.pause()
+        # Start at the bottom (auto_scroll=True).
+        bottom_y = view.transcript.scroll_y
+        assert bottom_y > 0
+        await pilot.press("k")
+        await pilot.pause()
+        assert view.transcript.scroll_y < bottom_y
+
+
+async def test_j_k_in_input_inserts_literal_characters():
+    """While the message Input has focus, `j`/`k` are typed, not consumed as scroll."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        view = app.query_one(SessionView)
+        st = SessionState(id="typing", initial_prompt="p")
+        view.show_session(st)
+        view.input.focus()
+        await pilot.pause()
+        for ch in "jkj":
+            await pilot.press(ch)
+        await pilot.pause()
+        assert view.input.value == "jkj"
+
+
+async def test_j_k_navigate_session_list():
+    """`j`/`k` move the highlight in the session list, mirroring arrow keys."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        slv = app.query_one(SessionListView)
+        for i in range(3):
+            slv.add_session(SessionState(id=f"sess{i}", initial_prompt="p"))
+        await pilot.pause()
+        slv.list_view.focus()
+        slv.list_view.index = 0
+        await pilot.pause()
+        await pilot.press("j")
+        await pilot.pause()
+        assert slv.list_view.index == 1
+        await pilot.press("k")
+        await pilot.pause()
+        assert slv.list_view.index == 0
+
+
+async def test_j_k_scroll_plan_modal():
+    """Inside the plan modal, `j`/`k` scroll its inner VerticalScroll."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        plan = "# Plan\n\n" + "\n".join(f"- step {i}" for i in range(80))
+        app.push_screen(PlanApprovalModal(session_id="abc12345", plan_text=plan))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, PlanApprovalModal)
+        container = modal.scroll_container()
+        assert container is not None
+        before = container.scroll_y
+        await pilot.press("j")
+        await pilot.pause()
+        # Either scroll_y advances, or content fit and scroll_target_y stays
+        # zero — but in our 80-step plan the container is definitely overfull.
+        assert container.scroll_target_y > before
+
+
+async def test_question_modal_l_h_expand_collapse_long_option():
+    """`l`/`h` mirror right/left for expand/collapse on the focused long option."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(
+            QuestionModal(session_id="abc12345", question_input=_question_modal_payload())
+        )
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, QuestionModal)
+        # Move radio highlight onto the long option (third entry).
+        await pilot.press("down")
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("l")
+        await pilot.pause()
+        radios = list(modal.query(_CheckMarkRadio))
+        long_radio = next(r for r in radios if r._option_label == _LONG_OPTION_LABEL)
+        assert long_radio._expanded is True
+        await pilot.press("h")
+        await pilot.pause()
+        assert long_radio._expanded is False


### PR DESCRIPTION
Closes #50

GitHub issue [#50](https://github.com/Nixotica/chud/issues/50) asks that all
scrolling in chud be reachable via `j`/`k`, except when the user is typing.
The user additionally asked for `h`/`l` to drive expand/collapse on long
question options (the existing `right`/`left` behavior in `QuestionModal`),
and for the cross-modal pattern to be **consolidated** rather than copied.

The current app-level `k` binding is **Kill session** (`src/chud/app.py:60`),
so it must be rebound to free `k` for scroll-up. Per user choice: `k → x`.

---
PR made using [chud](https://github.com/Nixotica/chud).
