### PR TITLE
chore: Semantic helper functions for Textual/Rich markup

### DIFF
--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -18,6 +18,7 @@ from chud import gh as gh_mod
 from chud import state as state_mod
 from chud.gh import Issue
 from chud.manager import SessionManager
+from chud.markup import TextError, TextMuted, TextSuccess
 from chud.types import Event, EventKind, SessionStatus
 from chud.widgets.cleanup_confirmation_modal import CleanupConfirmationModal
 from chud.widgets.new_session_modal import NewSessionModal, NewSessionResult
@@ -473,7 +474,7 @@ class ChudApp(App[None]):
             repo = event.payload.get("repo", "")
             self.notify(f"Draft PR opened ({repo}): {url}")
             view = self.query_one(SessionView)
-            view.transcript.write(f"[bold green]+ draft PR:[/bold green] {repo} → {url}")
+            view.transcript.write(f"{TextSuccess('+ draft PR:')} {repo} → {url}")
             # Refresh the issues + PR-link caches now so the next `n` press
             # filters out the issue this PR just attached to, instead of
             # waiting for the 120s background tick. GitHub may need a moment
@@ -488,15 +489,13 @@ class ChudApp(App[None]):
             repo = event.payload.get("repo", "")
             self.notify(f"PR failed ({repo}): {err}", severity="error")
             view = self.query_one(SessionView)
-            view.transcript.write(f"[bold red]! PR failed:[/bold red] {repo or '(session)'}: {err}")
+            view.transcript.write(f"{TextError('! PR failed:')} {repo or '(session)'}: {err}")
         elif event.kind == EventKind.WORKTREE_DISCARDED:
             branch = event.payload.get("branch", "")
             repo = event.payload.get("repo", "")
             view = self.query_one(SessionView)
             view.transcript.write(
-                f"[dim]· discarded empty branch {branch}"
-                + (f" ({repo})" if repo else "")
-                + "[/dim]"
+                TextMuted(f"· discarded empty branch {branch}" + (f" ({repo})" if repo else ""))
             )
 
     # ------------------------------------------------------------------ prompt queue

--- a/src/chud/markup.py
+++ b/src/chud/markup.py
@@ -1,13 +1,3 @@
-"""Semantic helpers that wrap strings in Rich/Textual markup tags.
-
-Naming reflects the UI role of the text (``TextError``, ``TextHeading``, …)
-rather than the underlying tag, so re-skinning the TUI later is a search-
-and-replace on this module instead of every call site.
-
-Caller is responsible for escaping untrusted text — ``rich.markup.escape``
-is re-exported here for convenience so call sites need only one import.
-"""
-
 from __future__ import annotations
 
 from rich.markup import escape

--- a/src/chud/markup.py
+++ b/src/chud/markup.py
@@ -1,0 +1,99 @@
+"""Semantic helpers that wrap strings in Rich/Textual markup tags.
+
+Naming reflects the UI role of the text (``TextError``, ``TextHeading``, …)
+rather than the underlying tag, so re-skinning the TUI later is a search-
+and-replace on this module instead of every call site.
+
+Caller is responsible for escaping untrusted text — ``rich.markup.escape``
+is re-exported here for convenience so call sites need only one import.
+"""
+
+from __future__ import annotations
+
+from rich.markup import escape
+
+__all__ = [
+    "escape",
+    "TextError",
+    "TextSuccess",
+    "TextPrompt",
+    "TextDanger",
+    "TextHeading",
+    "TextMuted",
+    "TextStatusChange",
+    "TextStatus",
+    "TextPath",
+    "TextRepoLabel",
+    "TextToolName",
+    "TextPlanBanner",
+    "TextAttached",
+]
+
+
+def _wrap(tag: str, text: str) -> str:
+    return f"[{tag}]{text}[/{tag}]"
+
+
+def TextError(msg: str) -> str:
+    """Errors and blocking failures — bold red."""
+    return _wrap("bold red", msg)
+
+
+def TextSuccess(msg: str) -> str:
+    """Success notifications — bold green."""
+    return _wrap("bold green", msg)
+
+
+def TextPrompt(msg: str) -> str:
+    """Agent attention prompts — bold yellow."""
+    return _wrap("bold yellow", msg)
+
+
+def TextDanger(msg: str) -> str:
+    """Destructive-action copy (non-bold) — red."""
+    return _wrap("red", msg)
+
+
+def TextHeading(msg: str) -> str:
+    """Headings: modal titles, role labels, session ids — bold."""
+    return _wrap("bold", msg)
+
+
+def TextMuted(msg: str) -> str:
+    """Secondary metadata and descriptions — dim."""
+    return _wrap("dim", msg)
+
+
+def TextStatusChange(msg: str) -> str:
+    """Status-transition transcript line — dim italic."""
+    return _wrap("dim italic", msg)
+
+
+def TextStatus(msg: str) -> str:
+    """Status enum value in the session header — cyan."""
+    return _wrap("cyan", msg)
+
+
+def TextPath(msg: str) -> str:
+    """Filesystem paths — yellow."""
+    return _wrap("yellow", msg)
+
+
+def TextRepoLabel(msg: str) -> str:
+    """Repository name labels — yellow."""
+    return _wrap("yellow", msg)
+
+
+def TextToolName(msg: str) -> str:
+    """Tool names in the transcript — yellow."""
+    return _wrap("yellow", msg)
+
+
+def TextPlanBanner(msg: str) -> str:
+    """Plan-proposed banner — bold magenta."""
+    return _wrap("bold magenta", msg)
+
+
+def TextAttached(msg: str) -> str:
+    """Repo-attached notice — blue."""
+    return _wrap("blue", msg)

--- a/src/chud/widgets/cleanup_confirmation_modal.py
+++ b/src/chud/widgets/cleanup_confirmation_modal.py
@@ -4,6 +4,7 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Button, Static
 
+from chud.markup import TextDanger, TextHeading, TextMuted, TextPath, TextSuccess
 from chud.types import SessionState
 from chud.widgets._scrollable_modal import ScrollableModalScreen
 
@@ -93,11 +94,11 @@ class CleanupConfirmationModal(ScrollableModalScreen[bool]):
 
     def _compose_published(self) -> ComposeResult:
         yield Static(
-            f"[bold]Clean up session {self.state.id[:8]}? Work is pushed.[/bold]",
+            TextHeading(f"Clean up session {self.state.id[:8]}? Work is pushed."),
             id="title",
         )
         with VerticalScroll():
-            yield Static("[bold green]Draft PRs opened:[/bold green]")
+            yield Static(TextSuccess("Draft PRs opened:"))
             for pr in self.published_prs:
                 repo = pr.get("repo") or "(repo)"
                 url = pr.get("url") or ""
@@ -106,27 +107,27 @@ class CleanupConfirmationModal(ScrollableModalScreen[bool]):
             if self.state.attached_repos:
                 for wt in self.state.attached_repos.values():
                     yield Static(
-                        f"  • worktree:  [yellow]{wt.worktree_path}[/yellow]  "
-                        f"[dim](branch {wt.branch})[/dim]"
+                        f"  • worktree:  {TextPath(str(wt.worktree_path))}  "
+                        f"{TextMuted(f'(branch {wt.branch})')}"
                     )
             else:
-                yield Static("  [dim](no attached repos)[/dim]")
+                yield Static(f"  {TextMuted('(no attached repos)')}")
 
     def _compose_unpublished(self) -> ComposeResult:
         yield Static(
-            f"[bold]Clean up session {self.state.id[:8]}?[/bold]",
+            TextHeading(f"Clean up session {self.state.id[:8]}?"),
             id="title",
         )
         with VerticalScroll():
-            yield Static("This will [red]permanently delete[/red] every attached worktree:")
+            yield Static(f"This will {TextDanger('permanently delete')} every attached worktree:")
             if self.state.attached_repos:
                 for wt in self.state.attached_repos.values():
                     yield Static(
-                        f"  • worktree:  [yellow]{wt.worktree_path}[/yellow]  "
-                        f"[dim](branch {wt.branch})[/dim]"
+                        f"  • worktree:  {TextPath(str(wt.worktree_path))}  "
+                        f"{TextMuted(f'(branch {wt.branch})')}"
                     )
             else:
-                yield Static("  [dim](no attached repos)[/dim]")
+                yield Static(f"  {TextMuted('(no attached repos)')}")
             yield Static(
                 "\nUnpushed commits on the chud branch will be lost unless "
                 "you also enabled the draft-PR option."

--- a/src/chud/widgets/new_session_modal.py
+++ b/src/chud/widgets/new_session_modal.py
@@ -8,6 +8,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Button, Checkbox, Label, Select, Static, TextArea
 
 from chud.gh import Issue, build_issue_prompt
+from chud.markup import TextHeading
 from chud.options import EFFORT_VALUES, SESSION_OPTIONS
 from chud.state import (
     claude_settings_effort,
@@ -179,7 +180,7 @@ class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
 
     def compose(self) -> ComposeResult:
         with Vertical():
-            yield Static("[bold]New session[/bold]")
+            yield Static(TextHeading("New session"))
             body = VerticalScroll(id="body")
             # Let inner widgets own focus — matches QuestionModal's pattern so
             # tab-cycling lands on the prompt/options/effort controls rather

--- a/src/chud/widgets/plan_modal.py
+++ b/src/chud/widgets/plan_modal.py
@@ -5,6 +5,7 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Button, Input, Markdown, Static
 
+from chud.markup import TextHeading
 from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 
@@ -77,7 +78,10 @@ class PlanApprovalModal(ScrollableModalScreen[bool | str]):
 
     def compose(self) -> ComposeResult:
         with Vertical():
-            yield Static(f"[bold]Plan from session {self.session_id[:8]}[/bold]", id="plan-title")
+            yield Static(
+                TextHeading(f"Plan from session {self.session_id[:8]}"),
+                id="plan-title",
+            )
             with VerticalScroll():
                 yield Markdown(self.plan_text or "_(empty plan)_")
             with Horizontal():

--- a/src/chud/widgets/pr_review_modal.py
+++ b/src/chud/widgets/pr_review_modal.py
@@ -20,6 +20,7 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Button, Input, Label, Static, TextArea
 
+from chud.markup import TextHeading, TextMuted, TextRepoLabel
 from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 
@@ -111,15 +112,15 @@ class PRReviewModal(ScrollableModalScreen[PRReviewResult | None]):
     def compose(self) -> ComposeResult:
         with Vertical():
             yield Static(
-                f"[bold]Open draft PR(s) for session {self.session_id[:8]}?[/bold]",
+                TextHeading(f"Open draft PR(s) for session {self.session_id[:8]}?"),
                 id="pr-title-static",
             )
             with VerticalScroll(id="repos"):
                 if self._repos:
                     for label in self._repos:
-                        yield Static(f"  • [yellow]{label}[/yellow]")
+                        yield Static(f"  • {TextRepoLabel(label)}")
                 else:
-                    yield Static("  [dim](no attached repos)[/dim]")
+                    yield Static(f"  {TextMuted('(no attached repos)')}")
             yield Label("Title")
             yield Input(value=self._initial_title, id="title-input")
             yield Label("Body")

--- a/src/chud/widgets/question_modal.py
+++ b/src/chud/widgets/question_modal.py
@@ -14,6 +14,7 @@ from textual.style import Style
 from textual.widget import Widget
 from textual.widgets import Button, Checkbox, Input, RadioButton, RadioSet, Static
 
+from chud.markup import TextHeading, TextMuted
 from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 
@@ -302,7 +303,7 @@ class QuestionModal(ScrollableModalScreen[str | None]):
     def compose(self) -> ComposeResult:
         with Vertical():
             yield Static(
-                f"[bold]Question from session {self.session_id[:8]}[/bold]",
+                TextHeading(f"Question from session {self.session_id[:8]}"),
                 id="question-title",
             )
             scroll = VerticalScroll()
@@ -311,7 +312,7 @@ class QuestionModal(ScrollableModalScreen[str | None]):
                 for idx, q in enumerate(self.questions):
                     header = str(q.get("header") or "").strip()
                     if header:
-                        yield Static(f"[bold]{header}[/bold]", classes="question-header")
+                        yield Static(TextHeading(header), classes="question-header")
                     # Question body wraps naturally; no expand/collapse.
                     yield Static(
                         str(q.get("question") or "(no question text)"),
@@ -320,7 +321,7 @@ class QuestionModal(ScrollableModalScreen[str | None]):
                     )
                     raw = q.get("_raw")
                     if raw:
-                        yield Static(f"[dim]{raw}[/dim]")
+                        yield Static(TextMuted(str(raw)))
                     options = q.get("options") or []
                     multi = bool(q.get("multiSelect"))
                     if not options:

--- a/src/chud/widgets/session_view.py
+++ b/src/chud/widgets/session_view.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from rich.markup import escape
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import Input, RichLog, Static
 
+from chud.markup import (
+    TextAttached,
+    TextError,
+    TextHeading,
+    TextMuted,
+    TextPlanBanner,
+    TextPrompt,
+    TextStatus,
+    TextStatusChange,
+    TextToolName,
+    escape,
+)
 from chud.types import Event, EventKind, SessionState
 
 
@@ -86,7 +97,7 @@ class SessionView(Vertical):
         repo_names = sorted(wt.repo_path.name for wt in state.attached_repos.values())
         repos = ", ".join(repo_names) or "(no repos)"
         self.header.update(
-            f"[bold]{state.id[:8]}[/bold]  status=[cyan]{state.status.value}[/cyan]  repos: {repos}"
+            f"{TextHeading(state.id[:8])}  status={TextStatus(state.status.value)}  repos: {repos}"
         )
 
     def render_event(self, event: Event) -> None:
@@ -95,11 +106,12 @@ class SessionView(Vertical):
         if kind == EventKind.TRANSCRIPT_APPENDED:
             role = escape(str(p.get("role", "?")))
             if "text" in p:
-                self.transcript.write(f"[bold]{role}:[/bold] {escape(str(p['text']))}")
+                self.transcript.write(f"{TextHeading(f'{role}:')} {escape(str(p['text']))}")
             elif "tool_use" in p:
                 tu = p["tool_use"]
                 self.transcript.write(
-                    f"[dim]{role} → tool:[/dim] [yellow]{escape(str(tu.get('name')))}[/yellow] "
+                    f"{TextMuted(f'{role} → tool:')} "
+                    f"{TextToolName(escape(str(tu.get('name'))))} "
                     f"{escape(_short_json(tu.get('input')))}"
                 )
             # Other transcript shapes (raw SystemMessage init blobs, UserMessage
@@ -107,34 +119,32 @@ class SessionView(Vertical):
             # They remain in the in-memory event log and chud.log for debugging
             # and for a future verbose mode.
         elif kind == EventKind.STATUS_CHANGED:
-            self.transcript.write(f"[dim italic]→ {escape(str(p.get('status')))}[/dim italic]")
+            self.transcript.write(TextStatusChange(f"→ {escape(str(p.get('status')))}"))
         elif kind == EventKind.PLAN_PROPOSED:
-            self.transcript.write(
-                "[bold magenta]── Plan proposed (modal will open) ──[/bold magenta]"
-            )
+            self.transcript.write(TextPlanBanner("── Plan proposed (modal will open) ──"))
         elif kind == EventKind.QUESTION_ASKED:
             qs = (p.get("input") or {}).get("questions") or []
             first = ""
             if qs and isinstance(qs[0], dict):
                 first = str(qs[0].get("question") or qs[0].get("header") or "")
             preview = escape(first[:120]) if first else ""
-            line = "[bold yellow]? agent asked a question[/bold yellow]"
+            line = TextPrompt("? agent asked a question")
             if preview:
                 line = f"{line}: {preview}"
             self.transcript.write(line)
         elif kind == EventKind.NEEDS_USER_INPUT:
             msg = p.get("message") or p.get("reason", "agent waiting")
-            self.transcript.write(f"[bold red]? agent needs input: {escape(str(msg))}[/bold red]")
+            self.transcript.write(TextError(f"? agent needs input: {escape(str(msg))}"))
         elif kind == EventKind.REPO_ATTACHED:
             self.transcript.write(
-                f"[blue]+ attached:[/blue] {escape(str(p.get('repo')))} → "
+                f"{TextAttached('+ attached:')} {escape(str(p.get('repo')))} → "
                 f"{escape(str(p.get('worktree')))}"
             )
         elif kind == EventKind.UNKNOWN_MESSAGE:
             # Intentionally not rendered — kept in the event log + chud.log only.
             pass
         elif kind == EventKind.ERROR:
-            self.transcript.write(f"[bold red]ERROR:[/bold red] {escape(str(p.get('error')))}")
+            self.transcript.write(f"{TextError('ERROR:')} {escape(str(p.get('error')))}")
 
 
 def _short_json(obj: Any, limit: int = 120) -> str:

--- a/src/chud/widgets/settings_modal.py
+++ b/src/chud/widgets/settings_modal.py
@@ -23,6 +23,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Button, Checkbox, Input, Label, Static, TextArea
 
+from chud.markup import TextHeading, TextMuted
 from chud.options import SESSION_OPTIONS
 from chud.settings import (
     KEY_BRANCH_PREFIX,
@@ -120,7 +121,7 @@ class SettingsModal(ScrollableModalScreen[bool]):
         snapshot = load_settings()
         opt_defaults = user_default_options()
         with Vertical():
-            yield Static("[bold]chud settings[/bold]", id="title")
+            yield Static(TextHeading("chud settings"), id="title")
             with VerticalScroll(id="scroll"):
                 yield Label("Defaults for new sessions", classes="section")
                 for opt in SESSION_OPTIONS:
@@ -189,7 +190,7 @@ class SettingsModal(ScrollableModalScreen[bool]):
             return
         prefix = sanitize_branch_prefix(prefix_widget.value)
         example = f"{prefix}fix-auth-bug-3f9a2c" if include_slug_widget.value else f"{prefix}3f9a2c"
-        preview_widget.update(f"[dim]Preview: {example}[/dim]")
+        preview_widget.update(TextMuted(f"Preview: {example}"))
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "cancel":


### PR DESCRIPTION
## Summary
- Add `src/chud/markup.py` with role-named helpers (`TextError`, `TextHeading`, `TextMuted`, etc.) that wrap Rich/Textual markup tags.
- Replace hardcoded `[bold]…[/bold]`, `[dim]…[/dim]`, `[bold red]…[/bold red]` etc. throughout `app.py`, `widgets/session_view.py`, and the modal widgets so call sites read by UI role rather than ad-hoc tag pairs.
- Re-export `rich.markup.escape` from `chud.markup` so call sites need only one import.

This is the helper-consolidation slice cherry-picked from the now-superseded `chud/create-helper-functions-for-the-textual-ee094fc9` session branch — the draft-PR-review-modal work from that branch is dropped because main already has its own version (#53).

## Test plan
- [x] `pytest` (215 passed)
- [x] `ruff check .` + `ruff format --check .`
- [x] `pyright` (0 errors)
- [ ] Manual smoke: launch the TUI, open each modal (new session, plan approval, question, PR review, cleanup) and verify rendering looks unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)