### PR TITLE
fix: `j` / `k` navigation in the GitHub-issue picker

### DIFF
--- a/.github/workflows/release-unstable.yml
+++ b/.github/workflows/release-unstable.yml
@@ -20,7 +20,19 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Skip if this is a release commit
+        id: gate
+        run: |
+          sha="${{ github.event.workflow_run.head_sha }}"
+          if git show --name-only --pretty="" "$sha" | grep -qx VERSION; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Release commit detected; stable release workflow will handle it."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Python
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -28,14 +40,17 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install build tooling
+        if: steps.gate.outputs.skip != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install build
 
       - name: Build sdist + wheel
+        if: steps.gate.outputs.skip != 'true'
         run: python -m build
 
       - name: Resolve version
+        if: steps.gate.outputs.skip != 'true'
         id: version
         run: |
           version=$(ls dist/*.whl | head -n1 | sed -E 's|.*/chud-([^-]+)-.*|\1|')
@@ -44,6 +59,7 @@ jobs:
           echo "tag=unstable-$short_sha" >> "$GITHUB_OUTPUT"
 
       - name: Publish prerelease
+        if: steps.gate.outputs.skip != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,9 @@
             pkgs.ruff
             pkgs.pyright
             pkgs.git
+            pkgs.gh
             self.packages.${pkgs.system}.pre-commit
+            self.packages.${pkgs.system}.release
           ];
         };
       });
@@ -69,6 +71,86 @@
             pytest
 
             echo ">>> all checks passed"
+          '';
+        };
+
+        release = pkgs.writeShellApplication {
+          name = "release";
+          runtimeInputs = [ pkgs.git pkgs.gh ];
+          text = ''
+            set -euo pipefail
+
+            if [ $# -ne 1 ]; then
+              echo "usage: release X.Y.Z" >&2
+              exit 2
+            fi
+
+            version="$1"
+            if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][a-z0-9.-]+)?$ ]]; then
+              echo "error: version must look like X.Y.Z (got '$version')" >&2
+              exit 2
+            fi
+
+            tag="v$version"
+            branch="release/$tag"
+
+            current_branch=$(git rev-parse --abbrev-ref HEAD)
+            if [ "$current_branch" != "main" ]; then
+              echo "error: must be on main (currently on '$current_branch')" >&2
+              exit 2
+            fi
+
+            if ! git diff --quiet || ! git diff --cached --quiet; then
+              echo "error: working tree has uncommitted changes" >&2
+              exit 2
+            fi
+
+            echo ">>> fetching origin"
+            git fetch --tags origin main
+
+            if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+              echo "error: local main is not in sync with origin/main" >&2
+              exit 2
+            fi
+
+            if git rev-parse "$tag" >/dev/null 2>&1; then
+              echo "error: tag $tag already exists locally" >&2
+              exit 2
+            fi
+            if git ls-remote --tags --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
+              echo "error: tag $tag already exists on origin" >&2
+              exit 2
+            fi
+
+            if git show-ref --verify --quiet "refs/heads/$branch"; then
+              echo "error: branch $branch already exists locally" >&2
+              exit 2
+            fi
+
+            current_version=$(cat VERSION)
+            if [ "$current_version" = "$version" ]; then
+              echo "error: VERSION is already '$version'" >&2
+              exit 2
+            fi
+
+            echo ">>> creating branch $branch"
+            git checkout -b "$branch"
+            echo "$version" > VERSION
+            git add VERSION
+            git commit -m "release: $tag"
+
+            echo ">>> pushing $branch and opening PR"
+            git push -u origin "$branch"
+
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "release: $tag" \
+              --body "Bumps \`VERSION\` from \`$current_version\` to \`$version\`. Merging this PR will trigger the stable release workflow, which tags \`$tag\` and publishes a GitHub release with the built sdist + wheel."
+
+            echo
+            echo ">>> release PR opened. After it merges and Tests pass on main,"
+            echo "    .github/workflows/release.yml will publish $tag."
           '';
         };
       });

--- a/src/chud/widgets/_scrollable_modal.py
+++ b/src/chud/widgets/_scrollable_modal.py
@@ -13,7 +13,8 @@ from typing import TypeVar
 from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.screen import ModalScreen
-from textual.widgets import Input, TextArea
+from textual.widgets import Input, Select, TextArea
+from textual.widgets._select import SelectOverlay
 
 ScreenResultType = TypeVar("ScreenResultType")
 
@@ -36,7 +37,9 @@ class ScrollableModalScreen(ModalScreen[ScreenResultType]):
         return None
 
     def _vim_scroll(self, *, down: bool) -> None:
-        if isinstance(self.focused, Input | TextArea):
+        # Choice widgets own j/k while focused — let them navigate options
+        # rather than scrolling the modal body out from under the user.
+        if isinstance(self.focused, Input | TextArea | Select | SelectOverlay):
             return
         container = self.scroll_container()
         if container is None:

--- a/src/chud/widgets/_scrollable_modal.py
+++ b/src/chud/widgets/_scrollable_modal.py
@@ -4,16 +4,22 @@ Adds vim-style ``j``/``k`` scroll bindings that route to a single
 ``VerticalScroll`` exposed by the subclass via :py:meth:`scroll_container`.
 The bindings no-op while a text input owns focus, so the user can type
 literal ``j``/``k`` into prompts without scrolling the modal underneath.
+
+Also provides shared ``j``/``k`` focus navigation between option Checkboxes
+(those whose id starts with ``opt-``, the convention used for
+``SESSION_OPTIONS``-backed checkboxes in both ``NewSessionModal`` and
+``SettingsModal``).
 """
 
 from __future__ import annotations
 
 from typing import TypeVar
 
+from textual import events
 from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.screen import ModalScreen
-from textual.widgets import Input, Select, TextArea
+from textual.widgets import Checkbox, Input, Select, TextArea
 from textual.widgets._select import SelectOverlay
 
 ScreenResultType = TypeVar("ScreenResultType")
@@ -51,3 +57,34 @@ class ScrollableModalScreen(ModalScreen[ScreenResultType]):
 
     def action_vim_scroll_up(self) -> None:
         self._vim_scroll(down=False)
+
+    def on_key(self, event: events.Key) -> None:
+        """j/k focus between option Checkboxes (``opt-*`` id convention).
+
+        Without this, the screen-level j/k bindings would scroll the modal
+        body underneath a focused option Checkbox. We navigate in DOM order
+        among Checkboxes whose id starts with ``opt-`` and, at the
+        boundaries, fall through to ``focus_next``/``focus_previous`` so the
+        user can exit the option group cleanly into adjacent fields.
+        """
+        if event.key not in ("j", "k"):
+            return
+        focused = self.focused
+        if not isinstance(focused, Checkbox):
+            return
+        if not (focused.id or "").startswith("opt-"):
+            return
+        opts = [cb for cb in self.query(Checkbox) if (cb.id or "").startswith("opt-")]
+        try:
+            idx = opts.index(focused)
+        except ValueError:
+            return
+        event.stop()
+        event.prevent_default()
+        target = idx + 1 if event.key == "j" else idx - 1
+        if 0 <= target < len(opts):
+            opts[target].focus()
+        elif event.key == "j":
+            self.focus_next()
+        else:
+            self.focus_previous()

--- a/src/chud/widgets/_vim_select.py
+++ b/src/chud/widgets/_vim_select.py
@@ -1,0 +1,43 @@
+"""``Select`` subclass with vim-style ``j``/``k`` navigation.
+
+Drops Textual's stock type-to-search behavior in favor of explicit
+``j``/``k`` bindings: while the overlay is open they map to
+``cursor_down``/``cursor_up``; with the (closed) Select focused they open
+the overlay, matching how ``down``/``up`` already behave.
+
+Type-to-search may come back later as an explicit opt-in feature.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.widgets import Select
+from textual.widgets._select import SelectCurrent, SelectOverlay
+
+
+class VimSelectOverlay(SelectOverlay):
+    BINDINGS = [
+        *SelectOverlay.BINDINGS,
+        Binding("j", "cursor_down", show=False),
+        Binding("k", "cursor_up", show=False),
+    ]
+
+
+class VimSelect(Select[Any]):
+    BINDINGS = [
+        *Select.BINDINGS,
+        Binding("j,k", "show_overlay", show=False),
+    ]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # type_to_search is dropped wholesale for chud selects; force it
+        # off even if a caller passes True so we never regress.
+        kwargs["type_to_search"] = False
+        super().__init__(*args, **kwargs)
+
+    def compose(self) -> ComposeResult:
+        yield SelectCurrent(self.prompt)
+        yield VimSelectOverlay(type_to_search=False).data_bind(compact=Select.compact)

--- a/src/chud/widgets/new_session_modal.py
+++ b/src/chud/widgets/new_session_modal.py
@@ -19,6 +19,7 @@ from chud.state import (
 )
 from chud.types import KEY_EFFORT
 from chud.widgets._scrollable_modal import ScrollableModalScreen
+from chud.widgets._vim_select import VimSelect
 
 _EFFORT_CHOICES: tuple[tuple[str, str], ...] = tuple((v.capitalize(), v) for v in EFFORT_VALUES)
 
@@ -194,7 +195,7 @@ class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
                     issue_choices = tuple(
                         (self._format_issue_label(i), str(i.number)) for i in self._issues
                     )
-                    yield Select(
+                    yield VimSelect(
                         issue_choices,
                         id="issue",
                         allow_blank=True,
@@ -233,9 +234,9 @@ class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
                     "Default leaves it to the SDK; higher values trade speed for thoroughness."
                 )
                 if default_effort is None:
-                    yield Select(choices, id=KEY_EFFORT, allow_blank=True, tooltip=tooltip)
+                    yield VimSelect(choices, id=KEY_EFFORT, allow_blank=True, tooltip=tooltip)
                 else:
-                    yield Select(
+                    yield VimSelect(
                         choices,
                         id=KEY_EFFORT,
                         allow_blank=False,

--- a/tests/test_new_session_modal_vim_keys.py
+++ b/tests/test_new_session_modal_vim_keys.py
@@ -1,0 +1,107 @@
+"""Vim-key navigation in the New Session modal's GitHub-issue picker.
+
+Covers the regression where ``j``/``k`` were eaten by Textual's
+``SelectOverlay`` type-to-search instead of moving the option highlight,
+and the closed-Select case where ``j``/``k`` used to scroll the modal
+body underneath the focused widget.
+"""
+
+from __future__ import annotations
+
+from chud.app import ChudApp
+from chud.gh import Issue
+from chud.widgets._vim_select import VimSelect, VimSelectOverlay
+from chud.widgets.new_session_modal import NewSessionModal
+
+
+def _issue(number: int, title: str) -> Issue:
+    return Issue(
+        number=number,
+        title=title,
+        url=f"https://github.com/x/y/issues/{number}",
+        body="body",
+        state="OPEN",
+    )
+
+
+async def test_jk_navigates_open_issue_overlay():
+    issues = [_issue(1, "alpha"), _issue(2, "beta"), _issue(3, "gamma")]
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal(issues=issues))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+
+        select = modal.query_one("#issue", VimSelect)
+        select.focus()
+        await pilot.pause()
+        # Open the overlay; first option is highlighted by show_overlay.
+        await pilot.press("enter")
+        await pilot.pause()
+
+        overlay = modal.query_one(VimSelectOverlay)
+        assert overlay.highlighted == 0
+
+        await pilot.press("j")
+        await pilot.pause()
+        assert overlay.highlighted == 1
+
+        await pilot.press("j")
+        await pilot.pause()
+        assert overlay.highlighted == 2
+
+        await pilot.press("k")
+        await pilot.pause()
+        assert overlay.highlighted == 1
+
+
+async def test_type_to_search_is_disabled():
+    """A non-jk printable letter must not move the highlight — type-to-search
+    is intentionally turned off for chud's selects."""
+    issues = [_issue(1, "alpha"), _issue(2, "beta"), _issue(3, "gamma")]
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal(issues=issues))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+
+        select = modal.query_one("#issue", VimSelect)
+        select.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        overlay = modal.query_one(VimSelectOverlay)
+        assert overlay.highlighted == 0
+        # Pressing a letter that uniquely prefixes option 3 ("gamma") would
+        # have jumped to index 2 with type-to-search enabled. We disabled it,
+        # so the highlight should stay put.
+        await pilot.press("g")
+        await pilot.pause()
+        assert overlay.highlighted == 0
+
+
+async def test_jk_on_closed_select_opens_overlay():
+    """With the (closed) Select focused, ``j``/``k`` should open the overlay
+    (matching how ``down``/``up`` already behave) — not scroll the modal body."""
+    issues = [_issue(1, "alpha"), _issue(2, "beta")]
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal(issues=issues))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+
+        select = modal.query_one("#issue", VimSelect)
+        select.focus()
+        await pilot.pause()
+        assert not select.expanded
+
+        await pilot.press("j")
+        await pilot.pause()
+        assert select.expanded

--- a/tests/test_new_session_modal_vim_keys.py
+++ b/tests/test_new_session_modal_vim_keys.py
@@ -3,15 +3,21 @@
 Covers the regression where ``j``/``k`` were eaten by Textual's
 ``SelectOverlay`` type-to-search instead of moving the option highlight,
 and the closed-Select case where ``j``/``k`` used to scroll the modal
-body underneath the focused widget.
+body underneath the focused widget. Also covers the shared
+``opt-*`` Checkbox j/k navigation provided by ``ScrollableModalScreen``,
+which both ``NewSessionModal`` and ``SettingsModal`` inherit.
 """
 
 from __future__ import annotations
 
+from textual.widgets import Checkbox
+
 from chud.app import ChudApp
 from chud.gh import Issue
+from chud.options import SESSION_OPTIONS
 from chud.widgets._vim_select import VimSelect, VimSelectOverlay
 from chud.widgets.new_session_modal import NewSessionModal
+from chud.widgets.settings_modal import SettingsModal
 
 
 def _issue(number: int, title: str) -> Issue:
@@ -105,3 +111,62 @@ async def test_jk_on_closed_select_opens_overlay():
         await pilot.press("j")
         await pilot.pause()
         assert select.expanded
+
+
+async def test_jk_navigates_option_checkboxes():
+    """j/k should move focus between option Checkboxes rather than scroll
+    the modal body underneath."""
+    assert len(SESSION_OPTIONS) >= 2, "test assumes at least two options exist"
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal())
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+
+        first_id = f"opt-{SESSION_OPTIONS[0].id}"
+        second_id = f"opt-{SESSION_OPTIONS[1].id}"
+
+        modal.query_one(f"#{first_id}", Checkbox).focus()
+        await pilot.pause()
+
+        await pilot.press("j")
+        await pilot.pause()
+        assert isinstance(modal.focused, Checkbox)
+        assert modal.focused.id == second_id
+
+        await pilot.press("k")
+        await pilot.pause()
+        assert isinstance(modal.focused, Checkbox)
+        assert modal.focused.id == first_id
+
+
+async def test_jk_navigates_option_checkboxes_in_settings_modal(tmp_path, monkeypatch):
+    """The shared ``ScrollableModalScreen`` helper should also drive j/k
+    navigation between option Checkboxes in the settings modal."""
+    assert len(SESSION_OPTIONS) >= 2, "test assumes at least two options exist"
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(SettingsModal())
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, SettingsModal)
+
+        first_id = f"opt-{SESSION_OPTIONS[0].id}"
+        second_id = f"opt-{SESSION_OPTIONS[1].id}"
+
+        modal.query_one(f"#{first_id}", Checkbox).focus()
+        await pilot.pause()
+
+        await pilot.press("j")
+        await pilot.pause()
+        assert isinstance(modal.focused, Checkbox)
+        assert modal.focused.id == second_id
+
+        await pilot.press("k")
+        await pilot.pause()
+        assert isinstance(modal.focused, Checkbox)
+        assert modal.focused.id == first_id


### PR DESCRIPTION
In the **New Session** modal (`NewSessionModal`), the optional GitHub-issue picker is rendered with Textual's `Select` widget (`src/chud/widgets/new_session_modal.py:197`). The user reports that `j` / `k` don't move up / down through the issue list — only arrow keys work — even though the rest of chud is consistently vim-navigable (`SessionListView`, `ScrollableModalScreen`, app-level `j`/`k`).

There are **two** reasons `j`/`k` don't navigate the picker, depending on whether the dropdown is open:

1. **Dropdown open (`SelectOverlay` focused).** Textual's `SelectOverlay` (a subclass of `OptionList`, `textual/widgets/_select.py:48`) implements *type-to-search*: in `_on_key` (line 97) and `check_consume_key` (line 114) it consumes **every printable character**, using it to incrementally search option labels. So `j` and `k` get eaten as search input rather than firing any cursor binding. `OptionList` itself only binds `up`/`down` for cursor movement — `j`/`k` aren't bound by default.

2. **Dropdown closed (Select focused).** `Select.BINDINGS` only maps `enter,down,space,up` to `show_overlay` (line 290). `j`/`k` aren't bound, so they bubble up to `ScrollableModalScreen`'s `j`/`k` → `vim_scroll_down`/`vim_scroll_up` (`src/chud/widgets/_scrollable_modal.py:29-32`), which only no-ops for `Input | TextArea` focus (line 39). Result: with a Select focused, `j`/`k` *scrolls the modal body* — confusing.

The intended outcome: while a chud `Select` (or its open overlay) has focus, `j`/`k` move the highlight down/up exactly like the arrow keys. We're also dropping the upstream **type-to-search** behavior in chud's selects — it's a footgun (e.g. `e` jumps to a search match instead of navigating), and we may reintroduce it later as an explicit, opt-in feature.

---
PR made using [chud](https://github.com/Nixotica/chud).
