### PR TITLE
feat: Make chud installable via Nix flake

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,3 +56,23 @@ jobs:
 
       - name: Pyright
         run: nix develop --command bash -c "source .venv/bin/activate && pyright"
+
+  nix-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build chud package
+        run: nix build .#default
+
+      - name: Smoke test built binary
+        run: ./result/bin/chud --version

--- a/README.md
+++ b/README.md
@@ -10,7 +10,20 @@ Pre-alpha. Under active development.
 
 ## Install
 
-With [uv](https://docs.astral.sh/uv/) (recommended):
+### With Nix
+
+```sh
+nix run github:Nixotica/chud         # one-off
+nix profile install github:Nixotica/chud
+```
+
+Nix manages the Python interpreter and every dependency for you, and the
+wrapped `chud` binary already has `git`, `gh`, and `notify-send` on its
+`PATH`.
+
+### With uv, pipx, or pip
+
+With [uv](https://docs.astral.sh/uv/) (recommended for non-Nix users):
 
 ```sh
 uv tool install git+https://github.com/Nixotica/chud

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,81 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776659114,
+        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776715674,
+        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777463177,
+        "narHash": "sha256-1PcD0+IZPQXyvmXJ1OYH+23sRc9IyOKrUUBYZonVBm8=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "6c53dcf4d3f63240f57e0b0c826cb15eda61f249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,25 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    uv2nix = {
+      url = "github:pyproject-nix/uv2nix";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    pyproject-build-systems = {
+      url = "github:pyproject-nix/build-system-pkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, pyproject-nix, uv2nix, pyproject-build-systems }:
     let
       systems = [
         "x86_64-linux"
@@ -17,7 +33,49 @@
         nixpkgs.lib.genAttrs systems (system: f {
           inherit system;
           pkgs = import nixpkgs { inherit system; };
+          lib = nixpkgs.lib;
         });
+
+      # uv2nix workspace + dependency overlay are system-independent.
+      workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./.; };
+      uvOverlay = workspace.mkPyprojectOverlay { sourcePreference = "wheel"; };
+
+      # Local override: hatch-vcs has no .git inside the Nix sandbox, so we
+      # have to feed it a version via the env var setuptools-scm honours.
+      localOverlay = final: prev: {
+        chud = prev.chud.overrideAttrs (old: {
+          env = (old.env or { }) // {
+            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CHUD =
+              if self ? shortRev then self.shortRev else "0.0.0+dirty";
+          };
+        });
+      };
+
+      mkChud = { pkgs, lib, ... }:
+        let
+          pythonSet = (pkgs.callPackage pyproject-nix.build.packages {
+            python = pkgs.python312;
+          }).overrideScope (lib.composeManyExtensions [
+            pyproject-build-systems.overlays.default
+            uvOverlay
+            localOverlay
+          ]);
+          chudVenv = pythonSet.mkVirtualEnv "chud-env" workspace.deps.default;
+        in
+        pkgs.runCommand "chud"
+          {
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+            meta = {
+              description = "TUI for orchestrating multiple Claude Code agents in parallel";
+              homepage = "https://github.com/Nixotica/chud";
+              license = lib.licenses.mit;
+              mainProgram = "chud";
+            };
+          } ''
+          mkdir -p $out/bin
+          makeWrapper ${chudVenv}/bin/chud $out/bin/chud \
+            --prefix PATH : ${lib.makeBinPath [ pkgs.git pkgs.gh pkgs.libnotify ]}
+        '';
     in
     {
       devShells = forAllSystems ({ pkgs, ... }: {
@@ -33,7 +91,9 @@
         };
       });
 
-      packages = forAllSystems ({ pkgs, ... }: {
+      packages = forAllSystems ({ pkgs, lib, system }: {
+        default = mkChud { inherit pkgs lib; };
+
         pre-commit = pkgs.writeShellApplication {
           name = "pre-commit";
           runtimeInputs = [ pkgs.python312 pkgs.uv pkgs.ruff pkgs.pyright ];
@@ -70,6 +130,13 @@
 
             echo ">>> all checks passed"
           '';
+        };
+      });
+
+      apps = forAllSystems ({ system, ... }: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/chud";
         };
       });
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "chud"
 dynamic = ["version"]
 description = "TUI for orchestrating multiple Claude Code agents in parallel."
 readme = "README.md"
-requires-python = "==3.12.13"
+requires-python = ">=3.12,<3.13"
 authors = [{ name = "Nixotica" }]
 license = { text = "MIT" }
 dependencies = [

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/r4mzim3vkm1qmkf6j5pz45vhx2nqil7z-chud

--- a/src/chud/__init__.py
+++ b/src/chud/__init__.py
@@ -6,14 +6,14 @@ from importlib.metadata import version as _pkg_version
 # app.py/__main__.py) means *any* import path — entrypoint script, `python -m
 # chud`, or `import chud` — fails fast with a clear message before submodules
 # using 3.12-only syntax (e.g. `from datetime import UTC`) blow up cryptically.
-_REQUIRED_PYTHON = (3, 12, 13)
-if sys.version_info[:3] != _REQUIRED_PYTHON:
-    _required = ".".join(map(str, _REQUIRED_PYTHON))
+_REQUIRED_PYTHON = (3, 12)
+if sys.version_info[:2] != _REQUIRED_PYTHON:
+    _required = ".".join(map(str, _REQUIRED_PYTHON)) + ".x"
     _actual = ".".join(map(str, sys.version_info[:3]))
     sys.exit(
         f"chud requires Python {_required} but is running on {_actual}.\n"
         f"Reinstall with: "
-        f"uv tool install --python {_required} git+https://github.com/Nixotica/chud"
+        f"uv tool install --python 3.12 git+https://github.com/Nixotica/chud"
     )
 
 try:

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.12.13"
+requires-python = "==3.12.*"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
Closes #32

Today, installing `chud` requires the user to have Python 3.12.13 plus a working
`uv` / `pipx` / `pip` setup. Issue
[#32](https://github.com/Nixotica/chud/issues/32) calls for two install paths
that remove this friction: a pre-built binary, and a Nix flake install.

This plan addresses **only the Nix flake path** for now. The standalone
binary (PyInstaller / Nuitka) is explicitly deferred to a later issue.

The intended end-state for this work:

```sh
nix run github:Nixotica/chud         # one-off
nix profile install github:Nixotica/chud
```

…with Nix transparently provisioning the right Python interpreter and every
transitive dep listed in `uv.lock`. The user never installs Python or runs
`pip` / `uv`. At runtime, `git`, `gh`, and `notify-send` must remain reachable
on the wrapped binary's `PATH` because chud's `shutil.which` lookups in
`src/chud/worktree.py`, `src/chud/gh.py`, and `src/chud/notify.py` depend on
them.

The existing `devShells.default` and `packages.pre-commit` outputs in
`flake.nix` must remain untouched — current contributors should see no
behavioural change.

---
PR made using [chud](https://github.com/Nixotica/chud).
