### PR TITLE
feat: Allow non-auto-mode

### DIFF
--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -22,6 +22,7 @@ from chud.markup import TextError, TextMuted, TextSuccess
 from chud.types import Event, EventKind, SessionStatus
 from chud.widgets.cleanup_confirmation_modal import CleanupConfirmationModal
 from chud.widgets.new_session_modal import NewSessionModal, NewSessionResult
+from chud.widgets.permission_modal import PermissionModal
 from chud.widgets.plan_modal import PlanApprovalModal
 from chud.widgets.pr_review_modal import PRReviewModal, PRReviewResult
 from chud.widgets.question_modal import QuestionModal
@@ -32,7 +33,7 @@ from chud.worktree import detect_cwd_repo
 
 log = logging.getLogger(__name__)
 
-PromptKind = Literal["plan", "pr_review", "cleanup", "input", "question"]
+PromptKind = Literal["plan", "pr_review", "cleanup", "input", "question", "permission"]
 
 DevHook = Callable[["ChudApp"], Awaitable[None]]
 
@@ -89,6 +90,7 @@ class ChudApp(App[None]):
         self._open_cleanup_modals: set[str] = set()
         self._open_pr_review_modals: set[str] = set()
         self._open_question_modals: set[str] = set()
+        self._open_permission_modals: set[str] = set()
         # FIFO queue of blocking user-input requests from agents. The first
         # request is shown until resolved; later requests wait their turn so a
         # newly-arrived modal can't cover one the user hasn't answered yet.
@@ -265,6 +267,7 @@ class ChudApp(App[None]):
                 options=result.options,
                 effort=result.effort,
                 issue_number=result.issue.number if result.issue is not None else None,
+                run_mode=result.run_mode,
             )
         except Exception as e:
             log.exception("create_session failed")
@@ -448,6 +451,19 @@ class ChudApp(App[None]):
                     payload={"input": event.payload.get("input", {})},
                 )
             )
+        elif event.kind == EventKind.PERMISSION_REQUESTED:
+            # The session emits a fresh dict; copy here is the only one needed
+            # to isolate the modal's view of tool_input from the SDK round-trip.
+            self._enqueue_prompt(
+                PromptRequest(
+                    session_id=event.session_id,
+                    kind="permission",
+                    payload={
+                        "tool_name": event.payload.get("tool_name", ""),
+                        "tool_input": dict(event.payload.get("tool_input", {})),
+                    },
+                )
+            )
         elif event.kind == EventKind.CLEANUP_REQUESTED:
             self._enqueue_prompt(
                 PromptRequest(
@@ -544,6 +560,8 @@ class ChudApp(App[None]):
                 self._show_input_focus(req)
             elif req.kind == "question":
                 self._show_question_modal(req)
+            elif req.kind == "permission":
+                self._show_permission_modal(req)
             return
 
     def _resolve_active_prompt(self, req: PromptRequest) -> None:
@@ -714,6 +732,51 @@ class ChudApp(App[None]):
                     await sess.answer_question("(user dismissed the question without answering)")
             finally:
                 self._open_question_modals.discard(session_id)
+                self._resolve_active_prompt(req)
+
+        self.run_worker(show_modal(), exclusive=False)
+
+    def _show_permission_modal(self, req: PromptRequest) -> None:
+        session_id = req.session_id
+        tool_name = str(req.payload.get("tool_name", ""))
+        # No defensive copy: the dict was already isolated when the event
+        # was enqueued in ``_on_event``.
+        tool_input = req.payload.get("tool_input", {})
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        if session_id in self._open_permission_modals:
+            self._resolve_active_prompt(req)
+            return
+        self._open_permission_modals.add(session_id)
+
+        async def show_modal() -> None:
+            try:
+                result = await self.push_screen_wait(
+                    PermissionModal(
+                        session_id=session_id,
+                        tool_name=tool_name,
+                        tool_input=tool_input,
+                    )
+                )
+                sess = self.manager.sessions.get(session_id)
+                if sess is None:
+                    return
+                # PermissionModal returns (approved, reason) or None on
+                # unexpected dismissal. None falls through to a plain deny so
+                # the agent gets a deterministic answer either way.
+                approved = False
+                reason = ""
+                if isinstance(result, tuple) and len(result) == 2:
+                    approved = bool(result[0])
+                    reason = str(result[1] or "")
+                if approved:
+                    await sess.approve_tool()
+                elif reason:
+                    await sess.deny_tool(reason=reason)
+                else:
+                    await sess.deny_tool()
+            finally:
+                self._open_permission_modals.discard(session_id)
                 self._resolve_active_prompt(req)
 
         self.run_worker(show_modal(), exclusive=False)

--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -22,8 +22,8 @@ from chud.markup import TextError, TextMuted, TextSuccess
 from chud.types import Event, EventKind, SessionStatus
 from chud.widgets.cleanup_confirmation_modal import CleanupConfirmationModal
 from chud.widgets.new_session_modal import NewSessionModal, NewSessionResult
-from chud.widgets.permission_modal import PermissionModal
-from chud.widgets.plan_modal import PlanApprovalModal
+from chud.widgets.permission_modal import PermissionDecision, PermissionModal
+from chud.widgets.plan_modal import PlanApprovalModal, PlanDecision
 from chud.widgets.pr_review_modal import PRReviewModal, PRReviewResult
 from chud.widgets.question_modal import QuestionModal
 from chud.widgets.session_list import SessionListView, SessionRow
@@ -323,11 +323,20 @@ class ChudApp(App[None]):
         sid = self._selected_session_id
         if sid is None:
             return
+        await self._kill_session_and_cleanup(sid)
+
+    async def _kill_session_and_cleanup(self, sid: str) -> None:
+        """Kill ``sid`` and reset all UI/state slots that referenced it.
+
+        Shared by the ``x`` keybinding, the cleanup-modal flow, and the new
+        Kill buttons on the plan / permission modals so they can't drift apart.
+        """
         await self.manager.kill_session(sid)
         self.query_one(SessionListView).remove_session(sid)
         self._event_log.pop(sid, None)
-        self._selected_session_id = None
-        self.query_one(SessionView).show_session(None)
+        if self._selected_session_id == sid:
+            self._selected_session_id = None
+            self.query_one(SessionView).show_session(None)
         self._drop_session_prompts(sid)
 
     # ------------------------------------------------------------------ list selection
@@ -610,13 +619,19 @@ class ChudApp(App[None]):
                 result = await self.push_screen_wait(
                     PlanApprovalModal(session_id=session_id, plan_text=plan_text)
                 )
+                if isinstance(result, PlanDecision) and result.action == "kill":
+                    # Kill resolves the session's pending plan future via
+                    # AgentSession.stop() before tearing the session down, so
+                    # the SDK doesn't see a stranded control request.
+                    await self._kill_session_and_cleanup(session_id)
+                    return
                 sess = self.manager.sessions.get(session_id)
                 if sess is None:
                     return
-                if result is True:
+                if isinstance(result, PlanDecision) and result.action == "approve":
                     await sess.approve_plan()
-                elif isinstance(result, str) and result:
-                    await sess.reject_plan(reason=result)
+                elif isinstance(result, PlanDecision) and result.reason:
+                    await sess.reject_plan(reason=result.reason)
                 else:
                     await sess.reject_plan()
             finally:
@@ -645,15 +660,16 @@ class ChudApp(App[None]):
                 )
                 if not confirmed:
                     return
+                # Cleanup variant — kill_session(cleanup_worktrees=True) tears
+                # down the worktree as well as the in-memory session. We then
+                # mirror the same UI/state reset the shared helper does, since
+                # the helper doesn't accept the cleanup flag.
                 await self.manager.kill_session(session_id, cleanup_worktrees=True)
                 self.query_one(SessionListView).remove_session(session_id)
                 self._event_log.pop(session_id, None)
                 if self._selected_session_id == session_id:
                     self._selected_session_id = None
                     self.query_one(SessionView).show_session(None)
-                # Drop any other queued prompts (e.g. a stale PLAN_PROPOSED)
-                # for the now-killed session so the queue doesn't try to
-                # re-show them.
                 self._drop_session_prompts(session_id)
             finally:
                 self._open_cleanup_modals.discard(session_id)
@@ -758,21 +774,21 @@ class ChudApp(App[None]):
                         tool_input=tool_input,
                     )
                 )
+                if isinstance(result, PermissionDecision) and result.action == "kill":
+                    # AgentSession.stop() resolves the pending permission
+                    # future with a Deny so the SDK doesn't hang on the
+                    # in-flight tool call.
+                    await self._kill_session_and_cleanup(session_id)
+                    return
                 sess = self.manager.sessions.get(session_id)
                 if sess is None:
                     return
-                # PermissionModal returns (approved, reason) or None on
-                # unexpected dismissal. None falls through to a plain deny so
-                # the agent gets a deterministic answer either way.
-                approved = False
-                reason = ""
-                if isinstance(result, tuple) and len(result) == 2:
-                    approved = bool(result[0])
-                    reason = str(result[1] or "")
-                if approved:
+                # ``None`` (unexpected dismissal) falls through to a plain
+                # deny so the agent gets a deterministic answer either way.
+                if isinstance(result, PermissionDecision) and result.action == "approve":
                     await sess.approve_tool()
-                elif reason:
-                    await sess.deny_tool(reason=reason)
+                elif isinstance(result, PermissionDecision) and result.reason:
+                    await sess.deny_tool(reason=result.reason)
                 else:
                     await sess.deny_tool()
             finally:

--- a/src/chud/manager.py
+++ b/src/chud/manager.py
@@ -9,7 +9,13 @@ from pathlib import Path
 from chud import pr as pr_mod
 from chud import state as state_mod
 from chud.notify import desktop_notify
-from chud.options import OPT_MAKE_DRAFT_PR, OPT_SELF_CLEANUP, normalize_effort, normalize_options
+from chud.options import (
+    OPT_MAKE_DRAFT_PR,
+    OPT_SELF_CLEANUP,
+    normalize_effort,
+    normalize_options,
+    normalize_run_mode,
+)
 from chud.session import AgentSession
 from chud.types import Event, EventKind, SessionState, SessionStatus
 from chud.worktree import WorktreeManager, is_git_repo
@@ -59,6 +65,7 @@ class SessionManager:
         launch_cwd: Path | None = None,
         effort: str | None = None,
         issue_number: int | None = None,
+        run_mode: str | None = None,
     ) -> AgentSession:
         sid = _new_session_id()
         st = SessionState(
@@ -67,6 +74,7 @@ class SessionManager:
             options=normalize_options(options),
             effort=normalize_effort(effort),
             issue_number=issue_number,
+            run_mode=normalize_run_mode(run_mode),
         )
 
         wt_mgr = WorktreeManager(st)
@@ -94,6 +102,7 @@ class SessionManager:
             launch_cwd=launch_cwd,
             attach_callback=_attach_for_agent,
             effort=st.effort,
+            run_mode=st.run_mode,
         )
         self.sessions[sid] = sess
         self.worktrees[sid] = wt_mgr

--- a/src/chud/options.py
+++ b/src/chud/options.py
@@ -28,6 +28,45 @@ def normalize_effort(raw: object) -> EffortLevel | None:
     return None
 
 
+# Permission-mode policy for a chud session.
+#
+# - ``full_auto``: current behavior — after plan approval the SDK runs in
+#   ``acceptEdits`` mode and only plan/AskUserQuestion interrupt.
+# - ``default``: SDK runs in ``default`` mode after plan approval — the
+#   user's ``~/.claude/settings.json`` allow/deny rules apply, and chud
+#   surfaces a modal for any tool the SDK still asks about.
+# - ``low_perms``: SDK runs in ``acceptEdits`` after plan approval, but
+#   chud's PreToolUse hook unconditionally surfaces a modal for every
+#   Edit/Write/NotebookEdit/Bash call (read-only tools still pass).
+RunMode = Literal["full_auto", "default", "low_perms"]
+RUN_MODE_VALUES: tuple[RunMode, ...] = get_args(RunMode)
+RUN_MODE_DEFAULT: RunMode = "full_auto"
+
+# Tool names that low-perms requires explicit user approval for. Read-only
+# tools are deliberately omitted so the agent can still explore the worktree.
+LOW_PERMS_GATED_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "NotebookEdit", "Bash"})
+
+# (label, value) pairs for the run-mode Select in the new-session + settings
+# modals. Kept in this module so the two widgets stay in sync.
+RUN_MODE_CHOICES: tuple[tuple[str, RunMode], ...] = (
+    ("Full auto", "full_auto"),
+    ("Default (uses ~/.claude settings)", "default"),
+    ("Low-perms (prompt for each edit)", "low_perms"),
+)
+
+
+def normalize_run_mode(raw: object) -> RunMode:
+    """Coerce a persisted/raw run_mode value to a known choice.
+
+    Unknown / legacy / wrong-type values fall back to ``RUN_MODE_DEFAULT``
+    so a corrupted config can't crash the app and so the runtime branch
+    in ``session.py`` stays a simple ``==`` comparison.
+    """
+    if raw in RUN_MODE_VALUES:
+        return raw  # type: ignore[return-value]
+    return RUN_MODE_DEFAULT
+
+
 @dataclass(frozen=True)
 class SessionOption:
     id: str

--- a/src/chud/session.py
+++ b/src/chud/session.py
@@ -27,7 +27,7 @@ from claude_agent_sdk.types import (
     ToolPermissionContext,
 )
 
-from chud.options import EffortLevel
+from chud.options import LOW_PERMS_GATED_TOOLS, EffortLevel, normalize_run_mode
 from chud.state import worktrees_root
 from chud.tools import AttachCallback, build_chud_mcp_server
 from chud.types import Event, EventKind, SessionState, SessionStatus
@@ -54,12 +54,20 @@ class AgentSession:
         launch_cwd: Path | None = None,
         attach_callback: AttachCallback | None = None,
         effort: str | None = None,
+        run_mode: str | None = None,
     ) -> None:
         self.state = state
         self.model = model
         self._launch_cwd = launch_cwd
         self._attach_callback = attach_callback
         self.effort = effort
+        # Resolve to a known choice. ``run_mode`` arg overrides the value
+        # carried on ``state.run_mode`` (callers that route everything through
+        # the manager will pass them in sync; the kwarg makes it explicit for
+        # tests that build an AgentSession directly). Single source of truth
+        # lives on ``state.run_mode`` so it round-trips through persistence.
+        raw_mode = run_mode if run_mode is not None else state.run_mode
+        self.state.run_mode = normalize_run_mode(raw_mode)
         self.events: asyncio.Queue[Event] = asyncio.Queue()
         self._client: ClaudeSDKClient | None = None
         self._reader_task: asyncio.Task[None] | None = None
@@ -71,6 +79,14 @@ class AgentSession:
             asyncio.Future[PermissionResultAllow | PermissionResultDeny] | None
         ) = None
         self._pending_question_input: dict[str, Any] | None = None
+        # Single-slot future for per-tool permission prompts (``default`` and
+        # ``low_perms`` modes). Mirrors the ``_plan_decision`` /
+        # ``_question_decision`` pattern: at most one in-flight prompt; if a
+        # second arrives we resolve the prior with ``Deny("superseded")``.
+        self._permission_decision: (
+            asyncio.Future[PermissionResultAllow | PermissionResultDeny] | None
+        ) = None
+        self._pending_permission: dict[str, Any] | None = None
 
     # ------------------------------------------------------------------ lifecycle
 
@@ -152,6 +168,11 @@ class AgentSession:
         self._question_decision = None
         self._pending_question_input = None
 
+        if self._permission_decision is not None and not self._permission_decision.done():
+            self._permission_decision.set_result(PermissionResultDeny(message="Session stopped."))
+        self._permission_decision = None
+        self._pending_permission = None
+
         if self._client is not None:
             with contextlib.suppress(Exception):
                 await self._client.interrupt()
@@ -179,12 +200,27 @@ class AgentSession:
         await self._client.query(text)
 
     async def approve_plan(self) -> None:
-        """Approve the pending plan: switch to acceptEdits and let ExitPlanMode through."""
+        """Approve the pending plan and flip the SDK to the chosen permission mode.
+
+        ``run_mode`` determines the target SDK mode:
+          - ``full_auto`` and ``low_perms`` → ``acceptEdits``. ``low_perms``
+            relies on chud's PreToolUse hook to surface modals for each
+            dangerous tool; leaving the SDK in ``acceptEdits`` keeps the SDK
+            from double-prompting.
+          - ``default`` → ``default``. The SDK then respects the user's
+            ``~/.claude/settings.json`` allow/deny rules and routes the
+            fallthrough to chud's ``can_use_tool`` callback, which surfaces
+            a PermissionModal.
+        """
         if self._plan_decision is None or self._plan_decision.done():
             log.warning("approve_plan called with no pending decision (session %s)", self.state.id)
             return
         assert self._client is not None
-        await self._client.set_permission_mode("acceptEdits")
+        # Map chud RunMode → SDK permission_mode. Note: both literals happen
+        # to be the string ``"default"`` on the ``default`` branch — one is
+        # chud's RunMode value, the other is the SDK's permission_mode value.
+        sdk_mode = "default" if self.state.run_mode == "default" else "acceptEdits"
+        await self._client.set_permission_mode(sdk_mode)
         # Persist the approved plan text so downstream consumers (PR title/body)
         # can read it later, including across TUI restarts.
         if self._pending_plan_text:
@@ -220,6 +256,34 @@ class AgentSession:
         self._pending_question_input = None
         await self._set_status(SessionStatus.EXECUTING)
 
+    async def approve_tool(self) -> None:
+        """Resolve a pending per-tool permission prompt with allow.
+
+        Used by both ``default`` mode (via ``can_use_tool``) and ``low_perms``
+        mode (via ``PreToolUse`` hook). Status stays at EXECUTING — unlike
+        ``AskUserQuestion``, permission prompts don't represent the agent
+        going idle; the SDK is mid-tool-call awaiting our decision.
+        """
+        if self._permission_decision is None or self._permission_decision.done():
+            log.warning("approve_tool called with no pending decision (session %s)", self.state.id)
+            return
+        self._permission_decision.set_result(PermissionResultAllow())
+        self._permission_decision = None
+        self._pending_permission = None
+
+    async def deny_tool(self, reason: str = "User denied.") -> None:
+        """Resolve a pending per-tool permission prompt with deny.
+
+        ``reason`` is forwarded to the agent as the deny message, mirroring
+        ``reject_plan``'s free-text feedback channel.
+        """
+        if self._permission_decision is None or self._permission_decision.done():
+            log.warning("deny_tool called with no pending decision (session %s)", self.state.id)
+            return
+        self._permission_decision.set_result(PermissionResultDeny(message=reason))
+        self._permission_decision = None
+        self._pending_permission = None
+
     # ------------------------------------------------------------------ SDK callbacks
 
     async def _on_tool_request(
@@ -254,7 +318,39 @@ class AgentSession:
         if reason is not None:
             return PermissionResultDeny(message=reason)
 
+        # ``default`` mode: after plan approval the SDK is in its ``default``
+        # permission mode, which routes anything not auto-allowed by user
+        # settings through this callback. Surface a modal for it; ``low_perms``
+        # uses the PreToolUse hook instead (so this branch stays a no-op).
+        if self.state.run_mode == "default" and self.state.status in (
+            SessionStatus.EXECUTING,
+            SessionStatus.AWAITING_USER,
+        ):
+            return await self._await_permission(tool_name, tool_input)
+
         return PermissionResultAllow()
+
+    async def _await_permission(
+        self, tool_name: str, tool_input: dict[str, Any]
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        """Surface a PermissionModal and block until the user resolves it.
+
+        Single-slot future, mirroring ``_plan_decision`` /
+        ``_question_decision``. If a request arrives while another is
+        pending we resolve the prior with ``Deny("superseded")`` and log;
+        the SDK serialises tool calls per session in practice so this is
+        defensive.
+        """
+        if self._permission_decision is not None and not self._permission_decision.done():
+            log.warning("permission decision superseded for session %s", self.state.id)
+            self._permission_decision.set_result(PermissionResultDeny(message="superseded"))
+        self._pending_permission = {"tool_name": tool_name, "tool_input": dict(tool_input)}
+        self._permission_decision = asyncio.get_event_loop().create_future()
+        await self._emit(
+            EventKind.PERMISSION_REQUESTED,
+            {"tool_name": tool_name, "tool_input": dict(tool_input)},
+        )
+        return await self._permission_decision
 
     # Edit/Write/NotebookEdit expose the target path in their tool input under
     # these keys; we resolve and check it against attached worktrees.
@@ -344,19 +440,45 @@ class AgentSession:
         Unlike ``can_use_tool``, PreToolUse hooks fire even when permission_mode
         is ``acceptEdits`` — so this is the gate that actually runs once the
         user approves a plan.
+
+        ``low_perms`` mode also uses this hook to unconditionally prompt for
+        every Edit/Write/NotebookEdit/Bash, even when the user's
+        ``~/.claude/settings.json`` would have auto-allowed them.
         """
         tool_name = cast(str, input_data.get("tool_name", ""))
         tool_input = cast(dict[str, Any], input_data.get("tool_input", {}))
         reason = self._check_filesystem_access(tool_name, tool_input)
-        if reason is None:
-            return {}
-        return {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": reason,
+        if reason is not None:
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
             }
-        }
+
+        if (
+            self.state.run_mode == "low_perms"
+            and tool_name in LOW_PERMS_GATED_TOOLS
+            and self.state.status in (SessionStatus.EXECUTING, SessionStatus.AWAITING_USER)
+        ):
+            result = await self._await_permission(tool_name, tool_input)
+            if isinstance(result, PermissionResultDeny):
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": result.message or "User denied.",
+                    }
+                }
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                }
+            }
+
+        return {}
 
     async def _on_stop_hook(
         self,

--- a/src/chud/session.py
+++ b/src/chud/session.py
@@ -87,6 +87,13 @@ class AgentSession:
             asyncio.Future[PermissionResultAllow | PermissionResultDeny] | None
         ) = None
         self._pending_permission: dict[str, Any] | None = None
+        # Set when the user denies a plan or tool call. When the agent then
+        # ends its turn (ResultMessage), we route to AWAITING_USER instead of
+        # DONE so the user can either reply or kill the session — never the
+        # auto-PR / cleanup pipeline, which would otherwise treat a deny-driven
+        # giveup as a successful finish. Cleared when the user sends a fresh
+        # message (start of a new turn).
+        self._deny_pending: bool = False
 
     # ------------------------------------------------------------------ lifecycle
 
@@ -197,6 +204,7 @@ class AgentSession:
         if self.state.status == SessionStatus.AWAITING_USER:
             await self._set_status(SessionStatus.EXECUTING)
         self.state.pending_question = None
+        self._deny_pending = False
         await self._client.query(text)
 
     async def approve_plan(self) -> None:
@@ -237,6 +245,7 @@ class AgentSession:
         self._plan_decision.set_result(PermissionResultDeny(message=reason))
         self._plan_decision = None
         self._pending_plan_text = None
+        self._deny_pending = True
         await self._set_status(SessionStatus.PLANNING)
 
     async def answer_question(self, answer_text: str) -> None:
@@ -283,6 +292,7 @@ class AgentSession:
         self._permission_decision.set_result(PermissionResultDeny(message=reason))
         self._permission_decision = None
         self._pending_permission = None
+        self._deny_pending = True
 
     # ------------------------------------------------------------------ SDK callbacks
 
@@ -560,7 +570,26 @@ class AgentSession:
             # Full ResultMessage stats stay in chud.log; the UI just sees the
             # status transition emitted by _set_status.
             log.debug("ResultMessage for session %s: %s", self.state.id, _stringify(msg))
-            await self._set_status(SessionStatus.DONE)
+            if self._deny_pending:
+                # The agent ended its turn after the user denied an edit or
+                # rejected a plan. Don't treat this as a successful completion
+                # (which would auto-publish a PR / trigger cleanup); park the
+                # session in AWAITING_USER so the user can either reply with a
+                # follow-up or kill the session explicitly.
+                self._deny_pending = False
+                await self._set_status(SessionStatus.AWAITING_USER)
+                await self._emit(
+                    EventKind.NEEDS_USER_INPUT,
+                    {
+                        "reason": "deny_followup",
+                        "message": (
+                            "Agent ended its turn after your denial. Send a new "
+                            "message to continue, or kill the session."
+                        ),
+                    },
+                )
+            else:
+                await self._set_status(SessionStatus.DONE)
         else:
             log.warning("unknown SDK message type %s", type(msg).__name__)
             await self._emit(

--- a/src/chud/state.py
+++ b/src/chud/state.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from platformdirs import user_data_dir
 
-from chud.types import KEY_EFFORT, SessionState
+from chud.types import KEY_EFFORT, KEY_RUN_MODE, SessionState
 
 
 def data_root() -> Path:
@@ -83,6 +83,17 @@ def user_default_effort() -> str | None:
     from chud.options import normalize_effort
 
     return normalize_effort(load_user_config().get(KEY_EFFORT))
+
+
+def user_default_run_mode() -> str:
+    """Persisted default permission mode for new sessions.
+
+    Falls back to ``RunMode``'s default (``"full_auto"``) when unset,
+    unknown, or wrong-typed — same contract as ``normalize_run_mode``.
+    """
+    from chud.options import normalize_run_mode
+
+    return normalize_run_mode(load_user_config().get(KEY_RUN_MODE))
 
 
 def claude_settings_effort() -> str | None:

--- a/src/chud/types.py
+++ b/src/chud/types.py
@@ -23,6 +23,7 @@ KEY_OPTIONS = "options"
 KEY_APPROVED_PLAN = "approved_plan"
 KEY_EFFORT = "effort"
 KEY_ISSUE_NUMBER = "issue_number"
+KEY_RUN_MODE = "run_mode"
 
 
 class SessionStatus(StrEnum):
@@ -77,6 +78,11 @@ class SessionState:
     # the user picks an issue in the new-session modal; consumed by callers
     # that want to surface "an existing chud is working on issue #N" hints.
     issue_number: int | None = None
+    # Permission-mode policy chosen at session creation. One of the
+    # ``RunMode`` literals (``options.RUN_MODE_VALUES``). Controls what the
+    # session flips the SDK's ``permission_mode`` to after plan approval and
+    # whether chud surfaces per-tool permission modals.
+    run_mode: str = "full_auto"
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -92,12 +98,13 @@ class SessionState:
             KEY_APPROVED_PLAN: self.approved_plan,
             KEY_EFFORT: self.effort,
             KEY_ISSUE_NUMBER: self.issue_number,
+            KEY_RUN_MODE: self.run_mode,
         }
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> SessionState:
         # Imported lazily to avoid a circular import at module load.
-        from chud.options import normalize_effort, normalize_options
+        from chud.options import normalize_effort, normalize_options, normalize_run_mode
 
         return cls(
             id=d[KEY_ID],
@@ -114,6 +121,7 @@ class SessionState:
             approved_plan=d.get(KEY_APPROVED_PLAN),
             effort=normalize_effort(d.get(KEY_EFFORT)),
             issue_number=d.get(KEY_ISSUE_NUMBER),
+            run_mode=normalize_run_mode(d.get(KEY_RUN_MODE)),
         )
 
 
@@ -123,6 +131,7 @@ class EventKind(StrEnum):
     PLAN_PROPOSED = "plan_proposed"
     NEEDS_USER_INPUT = "needs_user_input"
     QUESTION_ASKED = "question_asked"
+    PERMISSION_REQUESTED = "permission_requested"
     REPO_ATTACHED = "repo_attached"
     UNKNOWN_MESSAGE = "unknown_message"
     ERROR = "error"

--- a/src/chud/widgets/new_session_modal.py
+++ b/src/chud/widgets/new_session_modal.py
@@ -248,7 +248,7 @@ class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
                         tooltip=tooltip,
                     )
                 yield Label("Permission mode:")
-                yield Select(
+                yield VimSelect(
                     RUN_MODE_CHOICES,
                     id=KEY_RUN_MODE,
                     allow_blank=False,

--- a/src/chud/widgets/new_session_modal.py
+++ b/src/chud/widgets/new_session_modal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import cast
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -9,15 +10,16 @@ from textual.widgets import Button, Checkbox, Label, Select, Static, TextArea
 
 from chud.gh import Issue, build_issue_prompt
 from chud.markup import TextHeading
-from chud.options import EFFORT_VALUES, SESSION_OPTIONS
+from chud.options import EFFORT_VALUES, RUN_MODE_CHOICES, RUN_MODE_DEFAULT, SESSION_OPTIONS
 from chud.state import (
     claude_settings_effort,
     load_user_config,
     save_user_config,
     user_default_effort,
     user_default_options,
+    user_default_run_mode,
 )
-from chud.types import KEY_EFFORT
+from chud.types import KEY_EFFORT, KEY_RUN_MODE
 from chud.widgets._scrollable_modal import ScrollableModalScreen
 from chud.widgets.check_mark_toggles import CheckMarkBox
 
@@ -36,6 +38,7 @@ class NewSessionResult:
     options: dict[str, bool] = field(default_factory=user_default_options)
     effort: str | None = None
     issue: Issue | None = None
+    run_mode: str = RUN_MODE_DEFAULT
 
 
 class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
@@ -243,6 +246,19 @@ class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
                         value=default_effort,
                         tooltip=tooltip,
                     )
+                yield Label("Permission mode:")
+                yield Select(
+                    RUN_MODE_CHOICES,
+                    id=KEY_RUN_MODE,
+                    allow_blank=False,
+                    value=user_default_run_mode(),
+                    tooltip=(
+                        "Controls what the session does after you approve the plan. "
+                        "Full auto = run unattended. Default = use your ~/.claude "
+                        "allow/deny rules and prompt for the rest. Low-perms = prompt "
+                        "for every Edit/Write/Bash."
+                    ),
+                )
             with Horizontal(id="buttons"):
                 yield Button("Cancel (Esc)", id="cancel")
                 yield Button("Start (F2)", id="start", variant="success")
@@ -297,6 +313,7 @@ class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
         config = load_user_config()
         config.update(options)
         config[KEY_EFFORT] = self._read_effort()
+        config[KEY_RUN_MODE] = self._read_run_mode()
         save_user_config(config)
         self.app.notify("Saved as defaults.")
 
@@ -306,6 +323,11 @@ class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
         if not isinstance(raw, str):
             return None
         return raw
+
+    def _read_run_mode(self) -> str:
+        """Read the run-mode Select. ``allow_blank=False`` on the widget
+        guarantees a string is returned."""
+        return cast(str, self.query_one(f"#{KEY_RUN_MODE}", Select).value)
 
     def action_cancel(self) -> None:
         self.dismiss(None)
@@ -341,5 +363,6 @@ class NewSessionModal(ScrollableModalScreen[NewSessionResult | None]):
                 options=options,
                 effort=self._read_effort(),
                 issue=self._read_issue(),
+                run_mode=self._read_run_mode(),
             )
         )

--- a/src/chud/widgets/permission_modal.py
+++ b/src/chud/widgets/permission_modal.py
@@ -1,0 +1,175 @@
+"""Modal asking the user to approve or deny a single tool call.
+
+Surfaced by ``AgentSession`` when a permission decision is needed:
+
+- ``run_mode == "default"`` and the SDK calls ``can_use_tool`` for a tool that
+  the user's ``~/.claude/settings.json`` allow/deny rules didn't resolve.
+- ``run_mode == "low_perms"`` and the agent invokes any of
+  ``options.LOW_PERMS_GATED_TOOLS`` (Edit / Write / NotebookEdit / Bash).
+
+Both paths use ``AgentSession._await_permission`` to block on a future; the
+modal's dismiss value resolves it. Mirrors the keyboard vocabulary of
+``PlanApprovalModal`` (a / r / Enter / Esc) so users move between modals
+without context switching.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import Button, Input, Static
+
+from chud.markup import TextHeading
+from chud.widgets._scrollable_modal import ScrollableModalScreen
+
+
+class PermissionModal(ScrollableModalScreen[tuple[bool, str] | None]):
+    """Ask the user to approve/deny a single tool call.
+
+    Dismiss values:
+      - ``(True, "")``  — approve.
+      - ``(False, "")`` — plain deny (sent to the agent as the default deny
+        message).
+      - ``(False, reason)`` — deny with free-text feedback. ``reason`` is
+        forwarded to the agent as the deny message, same channel
+        ``reject_plan`` uses.
+      - ``None`` — defensive; resolved by the caller as a plain deny.
+    """
+
+    DEFAULT_CSS = """
+    PermissionModal {
+        align: center middle;
+    }
+    PermissionModal > Vertical {
+        width: 90%;
+        max-width: 120;
+        height: 80%;
+        background: $surface;
+        border: round $accent;
+        padding: 1 2;
+    }
+    PermissionModal #permission-title {
+        height: 1;
+        color: $accent;
+    }
+    PermissionModal #tool-name {
+        height: 1;
+        margin-top: 1;
+        color: $accent;
+    }
+    PermissionModal VerticalScroll {
+        height: 1fr;
+        margin-top: 1;
+        margin-bottom: 1;
+    }
+    PermissionModal Horizontal {
+        height: 3;
+        align: right middle;
+    }
+    PermissionModal Button {
+        margin-left: 2;
+    }
+    PermissionModal #respond-input {
+        display: none;
+        height: 3;
+        margin-top: 1;
+    }
+    PermissionModal #respond-input.visible {
+        display: block;
+    }
+    """
+
+    BINDINGS = [
+        Binding("a", "approve", "Approve"),
+        Binding("r", "deny", "Deny"),
+        Binding("enter", "respond", "Deny with feedback"),
+        Binding("escape", "deny", "Deny"),
+    ]
+
+    def __init__(
+        self,
+        session_id: str,
+        tool_name: str,
+        tool_input: dict[str, Any],
+    ) -> None:
+        super().__init__()
+        self.session_id = session_id
+        self.tool_name = tool_name or "(unknown)"
+        self.tool_input = tool_input or {}
+
+    def scroll_container(self) -> VerticalScroll | None:
+        try:
+            return self.query_one(VerticalScroll)
+        except Exception:
+            return None
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static(
+                TextHeading(f"Tool permission — session {self.session_id[:8]}"),
+                id="permission-title",
+            )
+            yield Static(TextHeading(self.tool_name), id="tool-name")
+            with VerticalScroll():
+                # Pretty-print so paths and command strings are scannable. The
+                # default=str fallback handles non-JSON types (Path, etc.) that
+                # the agent occasionally passes through.
+                try:
+                    body = json.dumps(self.tool_input, indent=2, default=str)
+                except Exception:
+                    body = repr(self.tool_input)
+                yield Static(body, markup=False)
+            with Horizontal():
+                # Buttons stay mouse-clickable but never grab keyboard focus,
+                # so a/r/enter/escape bindings always fire while the Input is
+                # hidden. Once the Input is revealed and focused, it owns
+                # Enter (to submit) and printable characters.
+                deny_btn = Button("Deny (r)", id="deny", variant="error")
+                deny_btn.can_focus = False
+                yield deny_btn
+                respond_btn = Button("Deny w/ feedback (Enter)", id="respond")
+                respond_btn.can_focus = False
+                yield respond_btn
+                approve_btn = Button("Approve (a)", id="approve", variant="success")
+                approve_btn.can_focus = False
+                yield approve_btn
+            yield Input(placeholder="Reason… (Enter to send)", id="respond-input")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "approve":
+            self.dismiss((True, ""))
+        elif event.button.id == "deny":
+            self.dismiss((False, ""))
+        elif event.button.id == "respond":
+            self.action_respond()
+
+    def action_approve(self) -> None:
+        self.dismiss((True, ""))
+
+    def action_deny(self) -> None:
+        self.dismiss((False, ""))
+
+    def action_respond(self) -> None:
+        """First press reveals the input + focuses it; second Enter (handled
+        by ``_on_respond_submitted`` below) dispatches the deny with the
+        typed reason."""
+        try:
+            inp = self.query_one("#respond-input", Input)
+        except Exception:
+            return
+        if "visible" not in inp.classes:
+            inp.add_class("visible")
+            inp.focus()
+
+    @on(Input.Submitted, "#respond-input")
+    def _on_respond_submitted(self, event: Input.Submitted) -> None:
+        text = event.value.strip()
+        # Empty submit collapses to a plain deny so the user can't accidentally
+        # forward a no-op message; any non-empty string becomes the deny
+        # reason.
+        self.dismiss((False, text))

--- a/src/chud/widgets/permission_modal.py
+++ b/src/chud/widgets/permission_modal.py
@@ -9,14 +9,15 @@ Surfaced by ``AgentSession`` when a permission decision is needed:
 
 Both paths use ``AgentSession._await_permission`` to block on a future; the
 modal's dismiss value resolves it. Mirrors the keyboard vocabulary of
-``PlanApprovalModal`` (a / r / Enter / Esc) so users move between modals
+``PlanApprovalModal`` (a / r / x / Enter / Esc) so users move between modals
 without context switching.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from textual import on
 from textual.app import ComposeResult
@@ -28,16 +29,34 @@ from chud.markup import TextHeading
 from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 
-class PermissionModal(ScrollableModalScreen[tuple[bool, str] | None]):
+@dataclass(frozen=True)
+class PermissionDecision:
+    """User's choice on the per-tool permission modal.
+
+    ``action`` is one of:
+      - ``approve`` — let the agent execute this tool call.
+      - ``deny`` — block this call. ``reason`` carries any typed feedback
+        (empty for a plain deny).
+      - ``kill`` — terminate the session outright. Used when the user has
+        seen enough and wants to stop the agent rather than answer this
+        prompt-after-prompt.
+    """
+
+    action: Literal["approve", "deny", "kill"]
+    reason: str = ""
+
+
+class PermissionModal(ScrollableModalScreen[PermissionDecision | None]):
     """Ask the user to approve/deny a single tool call.
 
     Dismiss values:
-      - ``(True, "")``  — approve.
-      - ``(False, "")`` — plain deny (sent to the agent as the default deny
-        message).
-      - ``(False, reason)`` — deny with free-text feedback. ``reason`` is
-        forwarded to the agent as the deny message, same channel
-        ``reject_plan`` uses.
+      - ``PermissionDecision("approve")`` — approve.
+      - ``PermissionDecision("deny")`` — plain deny (sent to the agent as
+        the default deny message).
+      - ``PermissionDecision("deny", reason)`` — deny with free-text
+        feedback. ``reason`` is forwarded to the agent as the deny message,
+        same channel ``reject_plan`` uses.
+      - ``PermissionDecision("kill")`` — user wants the session terminated.
       - ``None`` — defensive; resolved by the caller as a plain deny.
     """
 
@@ -87,6 +106,7 @@ class PermissionModal(ScrollableModalScreen[tuple[bool, str] | None]):
     BINDINGS = [
         Binding("a", "approve", "Approve"),
         Binding("r", "deny", "Deny"),
+        Binding("x", "kill", "Kill session"),
         Binding("enter", "respond", "Deny with feedback"),
         Binding("escape", "deny", "Deny"),
     ]
@@ -126,10 +146,13 @@ class PermissionModal(ScrollableModalScreen[tuple[bool, str] | None]):
                 yield Static(body, markup=False)
             with Horizontal():
                 # Buttons stay mouse-clickable but never grab keyboard focus,
-                # so a/r/enter/escape bindings always fire while the Input is
-                # hidden. Once the Input is revealed and focused, it owns
+                # so a/r/k/enter/escape bindings always fire while the Input
+                # is hidden. Once the Input is revealed and focused, it owns
                 # Enter (to submit) and printable characters.
-                deny_btn = Button("Deny (r)", id="deny", variant="error")
+                kill_btn = Button("Kill session (x)", id="kill", variant="error")
+                kill_btn.can_focus = False
+                yield kill_btn
+                deny_btn = Button("Deny (r)", id="deny", variant="warning")
                 deny_btn.can_focus = False
                 yield deny_btn
                 respond_btn = Button("Deny w/ feedback (Enter)", id="respond")
@@ -142,17 +165,22 @@ class PermissionModal(ScrollableModalScreen[tuple[bool, str] | None]):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "approve":
-            self.dismiss((True, ""))
+            self.dismiss(PermissionDecision("approve"))
         elif event.button.id == "deny":
-            self.dismiss((False, ""))
+            self.dismiss(PermissionDecision("deny"))
+        elif event.button.id == "kill":
+            self.dismiss(PermissionDecision("kill"))
         elif event.button.id == "respond":
             self.action_respond()
 
     def action_approve(self) -> None:
-        self.dismiss((True, ""))
+        self.dismiss(PermissionDecision("approve"))
 
     def action_deny(self) -> None:
-        self.dismiss((False, ""))
+        self.dismiss(PermissionDecision("deny"))
+
+    def action_kill(self) -> None:
+        self.dismiss(PermissionDecision("kill"))
 
     def action_respond(self) -> None:
         """First press reveals the input + focuses it; second Enter (handled
@@ -172,4 +200,4 @@ class PermissionModal(ScrollableModalScreen[tuple[bool, str] | None]):
         # Empty submit collapses to a plain deny so the user can't accidentally
         # forward a no-op message; any non-empty string becomes the deny
         # reason.
-        self.dismiss((False, text))
+        self.dismiss(PermissionDecision("deny", text))

--- a/src/chud/widgets/plan_modal.py
+++ b/src/chud/widgets/plan_modal.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Literal
+
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -9,15 +12,32 @@ from chud.markup import TextHeading
 from chud.widgets._scrollable_modal import ScrollableModalScreen
 
 
-class PlanApprovalModal(ScrollableModalScreen[bool | str]):
+@dataclass(frozen=True)
+class PlanDecision:
+    """User's choice on the plan-approval modal.
+
+    ``action`` is one of:
+      - ``approve`` — accept the plan and let the agent execute it.
+      - ``reject`` — send the plan back to the agent. ``reason`` carries any
+        typed feedback (empty for a plain reject).
+      - ``kill`` — terminate the session outright.
+    """
+
+    action: Literal["approve", "reject", "kill"]
+    reason: str = ""
+
+
+class PlanApprovalModal(ScrollableModalScreen[PlanDecision | None]):
     """Show the agent's proposed plan and gate execution on user approval.
 
-    Returns:
-        - True on approve
-        - False on plain reject (default rejection reason)
-        - str on respond: a non-empty user-typed reason. The caller should treat
-          this as a rejection whose deny message is the typed string, so the
-          agent can revise.
+    Dismiss values:
+      - ``PlanDecision("approve")`` — approve.
+      - ``PlanDecision("reject")`` — plain reject.
+      - ``PlanDecision("reject", reason)`` — reject with free-text feedback;
+        ``reason`` is forwarded to the agent as the deny message.
+      - ``PlanDecision("kill")`` — user wants the session terminated.
+      - ``None`` — defensive (unexpected dismissal); callers should treat it
+        as a plain reject so the agent still gets a deterministic answer.
     """
 
     DEFAULT_CSS = """
@@ -61,6 +81,7 @@ class PlanApprovalModal(ScrollableModalScreen[bool | str]):
     BINDINGS = [
         ("a", "approve", "Approve"),
         ("r", "reject", "Reject"),
+        ("x", "kill", "Kill session"),
         ("enter", "respond", "Respond"),
         ("escape", "reject", "Reject"),
     ]
@@ -86,11 +107,14 @@ class PlanApprovalModal(ScrollableModalScreen[bool | str]):
                 yield Markdown(self.plan_text or "_(empty plan)_")
             with Horizontal():
                 # Buttons remain mouse-clickable but never grab keyboard focus,
-                # so the screen's BINDINGS (a / r / enter / escape) always fire
-                # while the response Input is hidden. Once the Input is revealed
-                # and focused, it naturally takes priority for Enter (submit)
-                # and printable characters.
-                reject_btn = Button("Reject (r)", id="reject", variant="error")
+                # so the screen's BINDINGS always fire while the response Input
+                # is hidden. Once the Input is revealed and focused, it
+                # naturally takes priority for Enter (submit) and printable
+                # characters.
+                kill_btn = Button("Kill session (x)", id="kill", variant="error")
+                kill_btn.can_focus = False
+                yield kill_btn
+                reject_btn = Button("Reject (r)", id="reject", variant="warning")
                 reject_btn.can_focus = False
                 yield reject_btn
                 respond_btn = Button("Respond (Enter)", id="respond")
@@ -103,17 +127,22 @@ class PlanApprovalModal(ScrollableModalScreen[bool | str]):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "approve":
-            self.dismiss(True)
+            self.dismiss(PlanDecision("approve"))
         elif event.button.id == "reject":
-            self.dismiss(False)
+            self.dismiss(PlanDecision("reject"))
+        elif event.button.id == "kill":
+            self.dismiss(PlanDecision("kill"))
         elif event.button.id == "respond":
             self.action_respond()
 
     def action_approve(self) -> None:
-        self.dismiss(True)
+        self.dismiss(PlanDecision("approve"))
 
     def action_reject(self) -> None:
-        self.dismiss(False)
+        self.dismiss(PlanDecision("reject"))
+
+    def action_kill(self) -> None:
+        self.dismiss(PlanDecision("kill"))
 
     def action_respond(self) -> None:
         """First press reveals the input and focuses it; the Input widget
@@ -131,4 +160,4 @@ class PlanApprovalModal(ScrollableModalScreen[bool | str]):
         text = event.value.strip()
         # Empty submit collapses to a plain reject so the user can't accidentally
         # forward a no-op message; any non-empty string becomes the deny reason.
-        self.dismiss(text or False)
+        self.dismiss(PlanDecision("reject", text))

--- a/src/chud/widgets/settings_modal.py
+++ b/src/chud/widgets/settings_modal.py
@@ -42,6 +42,7 @@ from chud.state import (
 )
 from chud.types import KEY_RUN_MODE
 from chud.widgets._scrollable_modal import ScrollableModalScreen
+from chud.widgets._vim_select import VimSelect
 from chud.widgets.check_mark_toggles import CheckMarkBox
 
 
@@ -141,7 +142,7 @@ class SettingsModal(ScrollableModalScreen[bool]):
                     )
 
                 yield Label("Permission mode default", classes="section")
-                yield Select(
+                yield VimSelect(
                     RUN_MODE_CHOICES,
                     id="run-mode",
                     value=user_default_run_mode(),

--- a/src/chud/widgets/settings_modal.py
+++ b/src/chud/widgets/settings_modal.py
@@ -17,14 +17,15 @@ config.json`` atomically.
 from __future__ import annotations
 
 import contextlib
+from typing import cast
 
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.widgets import Button, Checkbox, Input, Label, Static, TextArea
+from textual.widgets import Button, Checkbox, Input, Label, Select, Static, TextArea
 
 from chud.markup import TextHeading, TextMuted
-from chud.options import SESSION_OPTIONS
+from chud.options import RUN_MODE_CHOICES, RUN_MODE_DEFAULT, SESSION_OPTIONS
 from chud.settings import (
     KEY_BRANCH_PREFIX,
     KEY_INCLUDE_SLUG,
@@ -33,7 +34,13 @@ from chud.settings import (
     sanitize_branch_prefix,
     save_settings,
 )
-from chud.state import load_user_config, save_user_config, user_default_options
+from chud.state import (
+    load_user_config,
+    save_user_config,
+    user_default_options,
+    user_default_run_mode,
+)
+from chud.types import KEY_RUN_MODE
 from chud.widgets._scrollable_modal import ScrollableModalScreen
 from chud.widgets.check_mark_toggles import CheckMarkBox
 
@@ -133,6 +140,20 @@ class SettingsModal(ScrollableModalScreen[bool]):
                         tooltip=opt.description,
                     )
 
+                yield Label("Permission mode default", classes="section")
+                yield Select(
+                    RUN_MODE_CHOICES,
+                    id="run-mode",
+                    value=user_default_run_mode(),
+                    allow_blank=False,
+                    tooltip=(
+                        "Default permission mode for new sessions. "
+                        "Full auto = unattended after plan approval. "
+                        "Default = use ~/.claude allow/deny rules; prompt for the rest. "
+                        "Low-perms = prompt for every Edit/Write/Bash."
+                    ),
+                )
+
                 yield Label("Branch format", classes="section")
                 yield Label("Branch prefix (e.g. `chud/`, `agent/`):", classes="field")
                 yield Input(
@@ -215,6 +236,13 @@ class SettingsModal(ScrollableModalScreen[bool]):
                 cfg[opt.id] = self.query_one(f"#opt-{opt.id}", Checkbox).value
             except Exception:
                 continue
+        # ``allow_blank=False`` on the Select guarantees a string here; we
+        # only fall back to the default if the widget is somehow missing
+        # (e.g. modal teardown raced with save).
+        try:
+            cfg[KEY_RUN_MODE] = cast(str, self.query_one("#run-mode", Select).value)
+        except Exception:
+            cfg[KEY_RUN_MODE] = RUN_MODE_DEFAULT
         save_user_config(cfg)
 
         try:

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -26,7 +26,7 @@ from chud.widgets.new_session_modal import (
     NewSessionModal,
     NewSessionResult,
 )
-from chud.widgets.plan_modal import PlanApprovalModal
+from chud.widgets.plan_modal import PlanApprovalModal, PlanDecision
 from chud.widgets.question_modal import QuestionModal, _CheckMarkRadio
 from chud.widgets.session_list import SessionListView, SessionRow
 from chud.widgets.session_view import SessionView
@@ -302,7 +302,7 @@ async def test_plan_modal_approve_via_a_key():
     app = ChudApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        result: list[bool | str | None] = []
+        result: list[PlanDecision | None] = []
         app.push_screen(
             PlanApprovalModal(session_id="abc12345", plan_text="# plan"),
             callback=lambda v: result.append(v),
@@ -310,14 +310,14 @@ async def test_plan_modal_approve_via_a_key():
         await pilot.pause()
         await pilot.press("a")
         await pilot.pause()
-        assert result == [True]
+        assert result == [PlanDecision("approve")]
 
 
 async def test_plan_modal_reject_via_r_key():
     app = ChudApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        result: list[bool | str | None] = []
+        result: list[PlanDecision | None] = []
         app.push_screen(
             PlanApprovalModal(session_id="abc12345", plan_text="# plan"),
             callback=lambda v: result.append(v),
@@ -325,14 +325,14 @@ async def test_plan_modal_reject_via_r_key():
         await pilot.pause()
         await pilot.press("r")
         await pilot.pause()
-        assert result == [False]
+        assert result == [PlanDecision("reject")]
 
 
 async def test_plan_modal_reject_via_escape():
     app = ChudApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        result: list[bool | str | None] = []
+        result: list[PlanDecision | None] = []
         app.push_screen(
             PlanApprovalModal(session_id="abc12345", plan_text="# plan"),
             callback=lambda v: result.append(v),
@@ -340,14 +340,29 @@ async def test_plan_modal_reject_via_escape():
         await pilot.pause()
         await pilot.press("escape")
         await pilot.pause()
-        assert result == [False]
+        assert result == [PlanDecision("reject")]
+
+
+async def test_plan_modal_kill_via_x_key():
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        result: list[PlanDecision | None] = []
+        app.push_screen(
+            PlanApprovalModal(session_id="abc12345", plan_text="# plan"),
+            callback=lambda v: result.append(v),
+        )
+        await pilot.pause()
+        await pilot.press("x")
+        await pilot.pause()
+        assert result == [PlanDecision("kill")]
 
 
 async def test_plan_modal_respond_with_typed_message():
     app = ChudApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        result: list[bool | str | None] = []
+        result: list[PlanDecision | None] = []
         app.push_screen(
             PlanApprovalModal(session_id="abc12345", plan_text="# plan"),
             callback=lambda v: result.append(v),
@@ -366,14 +381,50 @@ async def test_plan_modal_respond_with_typed_message():
         # Second Enter submits via Input.Submitted → on_respond_submitted.
         await pilot.press("enter")
         await pilot.pause()
-        assert result == ["use pathlib"]
+        assert result == [PlanDecision("reject", "use pathlib")]
+
+
+async def test_permission_modal_kill_via_x_key():
+    """Pressing `x` on the permission modal should dismiss with a kill
+    decision, mirroring the plan modal's behaviour."""
+    from chud.widgets.permission_modal import PermissionDecision, PermissionModal
+
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        result: list[PermissionDecision | None] = []
+        app.push_screen(
+            PermissionModal(session_id="abc12345", tool_name="Edit", tool_input={}),
+            callback=lambda v: result.append(v),
+        )
+        await pilot.pause()
+        await pilot.press("x")
+        await pilot.pause()
+        assert result == [PermissionDecision("kill")]
+
+
+async def test_permission_modal_deny_via_r_key():
+    from chud.widgets.permission_modal import PermissionDecision, PermissionModal
+
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        result: list[PermissionDecision | None] = []
+        app.push_screen(
+            PermissionModal(session_id="abc12345", tool_name="Edit", tool_input={}),
+            callback=lambda v: result.append(v),
+        )
+        await pilot.pause()
+        await pilot.press("r")
+        await pilot.pause()
+        assert result == [PermissionDecision("deny")]
 
 
 async def test_plan_modal_respond_empty_collapses_to_reject():
     app = ChudApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        result: list[bool | str | None] = []
+        result: list[PlanDecision | None] = []
         app.push_screen(
             PlanApprovalModal(session_id="abc12345", plan_text="# plan"),
             callback=lambda v: result.append(v),
@@ -383,7 +434,7 @@ async def test_plan_modal_respond_empty_collapses_to_reject():
         await pilot.pause()
         await pilot.press("enter")  # submit empty
         await pilot.pause()
-        assert result == [False]
+        assert result == [PlanDecision("reject", "")]
 
 
 _LONG_QUESTION_BODY = (

--- a/tests/test_new_session_modal_vim_keys.py
+++ b/tests/test_new_session_modal_vim_keys.py
@@ -15,6 +15,7 @@ from textual.widgets import Checkbox
 from chud.app import ChudApp
 from chud.gh import Issue
 from chud.options import SESSION_OPTIONS
+from chud.types import KEY_RUN_MODE
 from chud.widgets._vim_select import VimSelect, VimSelectOverlay
 from chud.widgets.new_session_modal import NewSessionModal
 from chud.widgets.settings_modal import SettingsModal
@@ -140,6 +141,32 @@ async def test_jk_navigates_option_checkboxes():
         await pilot.pause()
         assert isinstance(modal.focused, Checkbox)
         assert modal.focused.id == first_id
+
+
+async def test_run_mode_picker_uses_vim_select_in_new_session_modal():
+    """The permission-mode picker in the New Session modal should support
+    j/k navigation — i.e. be a ``VimSelect``, not a plain ``Select``."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(NewSessionModal())
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, NewSessionModal)
+        assert isinstance(modal.query_one(f"#{KEY_RUN_MODE}"), VimSelect)
+
+
+async def test_run_mode_picker_uses_vim_select_in_settings_modal(tmp_path, monkeypatch):
+    """Same guarantee for the settings modal's permission-mode default."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.push_screen(SettingsModal())
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, SettingsModal)
+        assert isinstance(modal.query_one("#run-mode"), VimSelect)
 
 
 async def test_jk_navigates_option_checkboxes_in_settings_modal(tmp_path, monkeypatch):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -4,10 +4,13 @@ from chud.options import (
     EFFORT_VALUES,
     OPT_MAKE_DRAFT_PR,
     OPT_SELF_CLEANUP,
+    RUN_MODE_DEFAULT,
+    RUN_MODE_VALUES,
     SESSION_OPTIONS,
     default_options,
     normalize_effort,
     normalize_options,
+    normalize_run_mode,
 )
 
 
@@ -67,3 +70,27 @@ def test_normalize_effort_rejects_unknown():
     assert normalize_effort("") is None
     assert normalize_effort(42) is None
     assert normalize_effort({"effort": "high"}) is None
+
+
+def test_run_mode_values_contains_three_modes():
+    assert set(RUN_MODE_VALUES) == {"full_auto", "default", "low_perms"}
+
+
+def test_run_mode_default_is_full_auto():
+    assert RUN_MODE_DEFAULT == "full_auto"
+
+
+def test_normalize_run_mode_accepts_known_values():
+    for mode in RUN_MODE_VALUES:
+        assert normalize_run_mode(mode) == mode
+
+
+def test_normalize_run_mode_handles_none_with_full_auto():
+    assert normalize_run_mode(None) == "full_auto"
+
+
+def test_normalize_run_mode_rejects_unknown_with_full_auto():
+    assert normalize_run_mode("bypass") == "full_auto"
+    assert normalize_run_mode("") == "full_auto"
+    assert normalize_run_mode(42) == "full_auto"
+    assert normalize_run_mode({"run_mode": "low_perms"}) == "full_auto"

--- a/tests/test_prompt_queue.py
+++ b/tests/test_prompt_queue.py
@@ -337,6 +337,39 @@ async def test_status_change_to_awaiting_user_keeps_input_prompt(tmp_path):
         assert app._prompt_active.kind == "input"
 
 
+def _permission_event(sid: str, tool_name: str = "Edit", tool_input: dict | None = None) -> Event:
+    return Event(
+        session_id=sid,
+        kind=EventKind.PERMISSION_REQUESTED,
+        payload={"tool_name": tool_name, "tool_input": dict(tool_input or {})},
+    )
+
+
+@pytest.mark.asyncio
+async def test_permission_requested_enqueues_as_permission_kind(tmp_path):
+    """PERMISSION_REQUESTED feeds the FIFO queue with kind='permission'."""
+    app = ChudApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        _register_session(app, "sess-a", tmp_path)
+        # Park a plan request first so the permission stays queued and we can
+        # inspect the request without racing the modal worker.
+        app._on_event(_plan_event("sess-a"))
+        await pilot.pause()
+        assert app._prompt_active is not None
+        assert app._prompt_active.kind == "plan"
+
+        app._on_event(_permission_event("sess-a", tool_name="Bash", tool_input={"command": "ls"}))
+        await pilot.pause()
+
+        # The permission request should be queued behind the active plan modal.
+        assert any(p.kind == "permission" for p in app._prompt_queue)
+        perm = next(p for p in app._prompt_queue if p.kind == "permission")
+        assert perm.session_id == "sess-a"
+        assert perm.payload["tool_name"] == "Bash"
+        assert perm.payload["tool_input"] == {"command": "ls"}
+
+
 @pytest.mark.asyncio
 async def test_cleanup_request_queues_behind_active_plan(tmp_path):
     app = ChudApp()

--- a/tests/test_session_permission.py
+++ b/tests/test_session_permission.py
@@ -1,0 +1,321 @@
+"""Tests for AgentSession's per-tool permission flow.
+
+Two modes route through this flow:
+
+- ``default`` mode uses the SDK's ``can_use_tool`` callback (chud's
+  ``_on_tool_request``).
+- ``low_perms`` mode uses the PreToolUse hook (chud's
+  ``_on_pre_tool_use_hook``).
+
+Both share ``_await_permission`` to surface a ``PERMISSION_REQUESTED``
+event, block on a future, and resolve via ``approve_tool`` / ``deny_tool``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+
+from chud.session import AgentSession
+from chud.types import EventKind, SessionState, SessionStatus, Worktree
+
+
+class FakeClient:
+    """Captures ``set_permission_mode`` calls for the approve-plan tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def connect(self) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def interrupt(self) -> None:
+        pass
+
+    async def query(self, *_a, **_kw) -> None:
+        pass
+
+    async def set_permission_mode(self, mode: str) -> None:
+        self.calls.append(f"set_permission_mode:{mode}")
+
+    async def receive_messages(self):
+        await asyncio.Event().wait()
+        if False:
+            yield  # pragma: no cover
+
+
+def _make_session(
+    run_mode: str,
+    *,
+    status: SessionStatus = SessionStatus.EXECUTING,
+    worktree_path: Path | None = None,
+) -> AgentSession:
+    """Build a session with an attached worktree so the filesystem gate
+    (which runs before the permission branch) doesn't pre-empt the test.
+
+    ``worktree_path`` lets callers pass a tmp path; if unset we use ``/`` so
+    any absolute file_path falls within it.
+    """
+    state = SessionState(id="t-perm", run_mode=run_mode)
+    state.status = status
+    wt_root = worktree_path if worktree_path is not None else Path("/")
+    state.attached_repos["fake"] = Worktree(
+        repo_path=Path("/tmp/repo"),
+        worktree_path=wt_root,
+        branch="chud/t-perm",
+    )
+    return AgentSession(state, run_mode=run_mode)
+
+
+async def _drain(events: asyncio.Queue, kind: EventKind, timeout: float = 1.0) -> dict:
+    """Pull events until we hit ``kind``, or fail on timeout."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            raise AssertionError(f"timed out waiting for {kind}")
+        ev = await asyncio.wait_for(events.get(), timeout=remaining)
+        if ev.kind == kind:
+            return ev.payload
+
+
+# ---------------------------------------------------------------- default mode
+
+
+async def test_default_mode_intercepts_can_use_tool_and_approves():
+    sess = _make_session("default")
+    tool_input = {"file_path": "/tmp/foo.py", "old_string": "a", "new_string": "b"}
+
+    request_task = asyncio.create_task(
+        sess._on_tool_request("Edit", tool_input, context=None)  # type: ignore[arg-type]
+    )
+    payload = await _drain(sess.events, EventKind.PERMISSION_REQUESTED)
+    assert payload["tool_name"] == "Edit"
+    assert payload["tool_input"] == tool_input
+    assert sess._permission_decision is not None and not sess._permission_decision.done()
+
+    await sess.approve_tool()
+    result = await asyncio.wait_for(request_task, timeout=1.0)
+    assert isinstance(result, PermissionResultAllow)
+    assert sess._permission_decision is None
+    assert sess._pending_permission is None
+
+
+async def test_default_mode_intercepts_can_use_tool_and_denies_with_reason():
+    sess = _make_session("default")
+    request_task = asyncio.create_task(
+        sess._on_tool_request("Edit", {"file_path": "/x"}, context=None)  # type: ignore[arg-type]
+    )
+    await _drain(sess.events, EventKind.PERMISSION_REQUESTED)
+
+    await sess.deny_tool(reason="too risky")
+    result = await asyncio.wait_for(request_task, timeout=1.0)
+    assert isinstance(result, PermissionResultDeny)
+    assert result.message == "too risky"
+
+
+# ---------------------------------------------------------------- low_perms mode
+
+
+async def test_low_perms_mode_intercepts_pre_tool_use_hook_and_approves():
+    sess = _make_session("low_perms")
+
+    request_task = asyncio.create_task(
+        sess._on_pre_tool_use_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/y"}},  # type: ignore[arg-type]
+            tool_use_id=None,
+            context=None,  # type: ignore[arg-type]
+        )
+    )
+    payload = await _drain(sess.events, EventKind.PERMISSION_REQUESTED)
+    assert payload["tool_name"] == "Edit"
+
+    await sess.approve_tool()
+    out = await asyncio.wait_for(request_task, timeout=1.0)
+    spec = cast(dict[str, Any], out)["hookSpecificOutput"]
+    assert spec["permissionDecision"] == "allow"
+
+
+async def test_low_perms_mode_intercepts_pre_tool_use_hook_and_denies_with_reason():
+    sess = _make_session("low_perms")
+
+    request_task = asyncio.create_task(
+        sess._on_pre_tool_use_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}},  # type: ignore[arg-type]
+            tool_use_id=None,
+            context=None,  # type: ignore[arg-type]
+        )
+    )
+    await _drain(sess.events, EventKind.PERMISSION_REQUESTED)
+
+    await sess.deny_tool(reason="nope, dangerous")
+    out = await asyncio.wait_for(request_task, timeout=1.0)
+    spec = cast(dict[str, Any], out)["hookSpecificOutput"]
+    assert spec["permissionDecision"] == "deny"
+    assert spec["permissionDecisionReason"] == "nope, dangerous"
+
+
+async def test_low_perms_only_gates_dangerous_tools():
+    """Read-only tools must pass through ``{}`` in low_perms without an event."""
+    sess = _make_session("low_perms")
+
+    out = await sess._on_pre_tool_use_hook(
+        {"tool_name": "Read", "tool_input": {"file_path": "/x"}},  # type: ignore[arg-type]
+        tool_use_id=None,
+        context=None,  # type: ignore[arg-type]
+    )
+    assert out == {}
+    assert sess.events.empty()
+    assert sess._permission_decision is None
+
+
+# ---------------------------------------------------------------- full_auto
+
+
+async def test_full_auto_skips_intercepts():
+    sess = _make_session("full_auto")
+
+    # can_use_tool allows immediately, no event, no future.
+    result = await sess._on_tool_request("Edit", {"file_path": "/x"}, context=None)  # type: ignore[arg-type]
+    assert isinstance(result, PermissionResultAllow)
+    assert sess._permission_decision is None
+    assert sess.events.empty()
+
+    # PreToolUse passes through with {} (no fs gate violation; no low_perms gate).
+    out = await sess._on_pre_tool_use_hook(
+        {"tool_name": "Edit", "tool_input": {"file_path": "/x"}},  # type: ignore[arg-type]
+        tool_use_id=None,
+        context=None,  # type: ignore[arg-type]
+    )
+    assert out == {}
+    assert sess.events.empty()
+
+
+# ---------------------------------------------------------------- status gating
+
+
+async def test_permission_skipped_during_planning_in_default_mode():
+    sess = _make_session("default", status=SessionStatus.PLANNING)
+    result = await sess._on_tool_request("Edit", {"file_path": "/x"}, context=None)  # type: ignore[arg-type]
+    assert isinstance(result, PermissionResultAllow)
+    assert sess._permission_decision is None
+    assert sess.events.empty()
+
+
+async def test_permission_skipped_during_planning_in_low_perms_mode():
+    sess = _make_session("low_perms", status=SessionStatus.PLANNING)
+    out = await sess._on_pre_tool_use_hook(
+        {"tool_name": "Edit", "tool_input": {"file_path": "/x"}},  # type: ignore[arg-type]
+        tool_use_id=None,
+        context=None,  # type: ignore[arg-type]
+    )
+    assert out == {}
+    assert sess._permission_decision is None
+    assert sess.events.empty()
+
+
+# ---------------------------------------------------------------- approve_plan SDK mode
+
+
+async def test_approve_plan_sets_acceptedits_in_full_auto_mode():
+    sess = _make_session("full_auto")
+    fake = FakeClient()
+    sess._client = fake  # type: ignore[assignment]
+    sess._plan_decision = asyncio.get_event_loop().create_future()
+
+    await sess.approve_plan()
+
+    assert "set_permission_mode:acceptEdits" in fake.calls
+
+
+async def test_approve_plan_sets_default_in_default_mode():
+    sess = _make_session("default")
+    fake = FakeClient()
+    sess._client = fake  # type: ignore[assignment]
+    sess._plan_decision = asyncio.get_event_loop().create_future()
+
+    await sess.approve_plan()
+
+    assert "set_permission_mode:default" in fake.calls
+
+
+async def test_approve_plan_sets_acceptedits_in_low_perms_mode():
+    """low_perms gates via PreToolUse, so the SDK still runs in acceptEdits
+    after plan approval — otherwise the SDK would also try to prompt for
+    dangerous tools and we'd double-prompt the user."""
+    sess = _make_session("low_perms")
+    fake = FakeClient()
+    sess._client = fake  # type: ignore[assignment]
+    sess._plan_decision = asyncio.get_event_loop().create_future()
+
+    await sess.approve_plan()
+
+    assert "set_permission_mode:acceptEdits" in fake.calls
+
+
+# ---------------------------------------------------------------- stop / supersede
+
+
+async def test_stop_resolves_in_flight_permission_decision():
+    sess = _make_session("default")
+    sess._client = FakeClient()  # type: ignore[assignment]
+    sess._permission_decision = asyncio.get_event_loop().create_future()
+    sess._pending_permission = {"tool_name": "Edit", "tool_input": {}}
+
+    pending = sess._permission_decision
+    await sess.stop()
+
+    assert pending.done()
+    result = pending.result()
+    assert isinstance(result, PermissionResultDeny)
+    assert result.message == "Session stopped."
+    assert sess._permission_decision is None
+    assert sess._pending_permission is None
+
+
+async def test_concurrent_permission_request_supersedes_prior():
+    """If two requests race, the first is resolved with Deny('superseded')."""
+    sess = _make_session("default")
+
+    first_task = asyncio.create_task(
+        sess._on_tool_request("Edit", {"file_path": "/a"}, context=None)  # type: ignore[arg-type]
+    )
+    await _drain(sess.events, EventKind.PERMISSION_REQUESTED)
+    first_future = sess._permission_decision
+    assert first_future is not None
+
+    second_task = asyncio.create_task(
+        sess._on_tool_request("Edit", {"file_path": "/b"}, context=None)  # type: ignore[arg-type]
+    )
+    await _drain(sess.events, EventKind.PERMISSION_REQUESTED)
+
+    # First future now resolved with the supersede deny; first awaiter sees it.
+    first_result = await asyncio.wait_for(first_task, timeout=1.0)
+    assert isinstance(first_result, PermissionResultDeny)
+    assert first_result.message == "superseded"
+
+    # Resolve the second one normally.
+    await sess.approve_tool()
+    second_result = await asyncio.wait_for(second_task, timeout=1.0)
+    assert isinstance(second_result, PermissionResultAllow)
+
+
+# ---------------------------------------------------------------- noop guards
+
+
+async def test_approve_tool_with_no_pending_decision_is_noop():
+    sess = _make_session("default")
+    await sess.approve_tool()
+    assert sess._permission_decision is None
+
+
+async def test_deny_tool_with_no_pending_decision_is_noop():
+    sess = _make_session("default")
+    await sess.deny_tool("nope")
+    assert sess._permission_decision is None

--- a/tests/test_session_permission.py
+++ b/tests/test_session_permission.py
@@ -319,3 +319,82 @@ async def test_deny_tool_with_no_pending_decision_is_noop():
     sess = _make_session("default")
     await sess.deny_tool("nope")
     assert sess._permission_decision is None
+
+
+# ---------------------------------------------------------------- deny → AWAITING_USER routing
+
+
+def _result_message() -> Any:
+    """Minimal ResultMessage stand-in matching the SDK's shape (all fields
+    that the dataclass requires). Reading isn't needed — only ``isinstance``
+    in ``_dispatch_message`` cares."""
+    from claude_agent_sdk import ResultMessage
+
+    return ResultMessage(
+        subtype="",
+        duration_ms=0,
+        duration_api_ms=0,
+        is_error=False,
+        num_turns=0,
+        session_id="t-perm",
+    )
+
+
+async def test_result_message_after_deny_routes_to_awaiting_user_not_done():
+    """A denied edit must not collapse the session into DONE — otherwise the
+    PR / cleanup pipeline fires on an aborted run. Park in AWAITING_USER so
+    the user can either reply or kill the session explicitly."""
+    sess = _make_session("default")
+    sess._permission_decision = asyncio.get_event_loop().create_future()
+    await sess.deny_tool("blocking this one")
+    assert sess._deny_pending is True
+
+    await sess._dispatch_message(_result_message())
+
+    assert sess.state.status == SessionStatus.AWAITING_USER
+    assert sess._deny_pending is False
+
+    # Sanity: a NEEDS_USER_INPUT event was emitted so the UI surfaces a
+    # prompt for the user.
+    saw_input = False
+    while not sess.events.empty():
+        ev = sess.events.get_nowait()
+        if ev.kind == EventKind.NEEDS_USER_INPUT:
+            saw_input = True
+            break
+    assert saw_input
+
+
+async def test_result_message_after_reject_plan_routes_to_awaiting_user_not_done():
+    """Same guarantee as the edit-deny path, applied to plan rejection. The
+    agent giving up after a rejected plan must not silently 'complete' and
+    trigger PR/cleanup."""
+    sess = _make_session("default", status=SessionStatus.AWAITING_PLAN_APPROVAL)
+    sess._plan_decision = asyncio.get_event_loop().create_future()
+    await sess.reject_plan(reason="try another approach")
+    assert sess._deny_pending is True
+    assert sess.state.status == SessionStatus.PLANNING
+
+    await sess._dispatch_message(_result_message())
+
+    assert sess.state.status == SessionStatus.AWAITING_USER
+    assert sess._deny_pending is False
+
+
+async def test_send_message_clears_deny_flag():
+    """A user-supplied follow-up resets the turn — the next ResultMessage
+    represents a fresh agent loop and should route to DONE normally."""
+
+    class _SilentClient:
+        async def query(self, *_a: Any, **_kw: Any) -> None:
+            pass
+
+    sess = _make_session("default")
+    sess._client = _SilentClient()  # type: ignore[assignment]
+    sess._deny_pending = True
+
+    await sess.send_message("try this instead")
+    assert sess._deny_pending is False
+
+    await sess._dispatch_message(_result_message())
+    assert sess.state.status == SessionStatus.DONE

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -146,6 +146,41 @@ def test_session_state_defaults_issue_number_to_none_when_absent():
     assert SessionState.from_dict(legacy).issue_number is None
 
 
+def test_session_state_roundtrips_run_mode():
+    s = SessionState(id="abc123", run_mode="low_perms")
+    d = s.to_dict()
+    assert d["run_mode"] == "low_perms"
+    assert SessionState.from_dict(d).run_mode == "low_perms"
+
+
+def test_session_state_default_run_mode_is_full_auto():
+    s = SessionState(id="x")
+    d = s.to_dict()
+    assert d["run_mode"] == "full_auto"
+    assert SessionState.from_dict(d).run_mode == "full_auto"
+
+
+def test_legacy_session_without_run_mode_loads_as_full_auto():
+    legacy = {
+        "id": "old1",
+        "status": SessionStatus.DONE.value,
+        "initial_prompt": "legacy",
+        "attached_repos": {},
+        "created_at": datetime.now(UTC).isoformat(),
+        "last_activity_at": datetime.now(UTC).isoformat(),
+        "pending_question": None,
+        "error": None,
+    }
+    assert SessionState.from_dict(legacy).run_mode == "full_auto"
+
+
+def test_session_state_normalizes_unknown_persisted_run_mode():
+    s = SessionState(id="x")
+    d = s.to_dict()
+    d["run_mode"] = "bypass-all-the-things"
+    assert SessionState.from_dict(d).run_mode == "full_auto"
+
+
 def test_legacy_session_with_workspace_dir_key_is_silently_ignored():
     """Pre-rename sessions.json entries carry a ``workspace_dir`` key. The
     field has been removed; loading must not raise."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -120,6 +120,23 @@ def test_render_pr_body_footer_unknown_placeholder_is_safe(tmp_path, monkeypatch
 # ---------------------------------------------------------------- snapshot
 
 
+def test_user_default_run_mode_defaults_to_full_auto(tmp_path, monkeypatch):
+    _redirect_config(tmp_path, monkeypatch)
+    assert state_mod.user_default_run_mode() == "full_auto"
+
+
+def test_user_default_run_mode_reads_persisted_value(tmp_path, monkeypatch):
+    _redirect_config(tmp_path, monkeypatch)
+    state_mod.save_user_config({"run_mode": "low_perms"})
+    assert state_mod.user_default_run_mode() == "low_perms"
+
+
+def test_user_default_run_mode_normalizes_unknown_value(tmp_path, monkeypatch):
+    _redirect_config(tmp_path, monkeypatch)
+    state_mod.save_user_config({"run_mode": "bypass-all"})
+    assert state_mod.user_default_run_mode() == "full_auto"
+
+
 def test_load_settings_returns_full_snapshot(tmp_path, monkeypatch):
     _redirect_config(tmp_path, monkeypatch)
     snap = settings_mod.load_settings()


### PR DESCRIPTION
Closes #49

Today every chud session hard-codes the post-plan-approval behavior to the SDK's
`acceptEdits` mode (`src/chud/session.py:110, 187`). If the user (or the agent's
own policy) can't operate in unattended mode, the agent silently can't edit and
the session finishes with no changes — which is what the user has been seeing as
empty PR bodies on otherwise-active sessions.

GitHub issue #49 asks for a "less permissive" alternative. The user wants three
modes, the chud default remains the current behavior, and the choice must be
settable both **per-session** (in the new-session modal) and **as a user
default** (in the settings modal).

---
PR made using [chud](https://github.com/Nixotica/chud).
