### PR TITLE
fix: gate `--dev` / `--seed` behind source-only access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ version-file = "src/chud/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/chud"]
+exclude = ["src/chud/dev.py"]
 
 [tool.ruff]
 line-length = 100

--- a/src/chud/app.py
+++ b/src/chud/app.py
@@ -815,7 +815,11 @@ def main() -> int:
     import argparse
 
     from chud import __version__
-    from chud.dev import SCENARIOS
+
+    try:
+        from chud.dev import SCENARIOS
+    except ImportError:
+        SCENARIOS = None
 
     parser = argparse.ArgumentParser(prog="chud")
     parser.add_argument(
@@ -823,18 +827,19 @@ def main() -> int:
         action="version",
         version=f"%(prog)s {__version__}",
     )
-    parser.add_argument(
-        "--dev",
-        choices=sorted(SCENARIOS.keys()),
-        default=None,
-        help="(pre-release) launch the TUI with a dev scenario on top",
-    )
-    parser.add_argument(
-        "--seed",
-        type=Path,
-        default=None,
-        help="(pre-release) JSON file overriding the default seed for --dev",
-    )
+    if SCENARIOS is not None:
+        parser.add_argument(
+            "--dev",
+            choices=sorted(SCENARIOS.keys()),
+            default=None,
+            help="(pre-release) launch the TUI with a dev scenario on top",
+        )
+        parser.add_argument(
+            "--seed",
+            type=Path,
+            default=None,
+            help="(pre-release) JSON file overriding the default seed for --dev",
+        )
     args = parser.parse_args()
 
     log_path = state_mod.data_root() / "chud.log"
@@ -843,7 +848,7 @@ def main() -> int:
         filename=log_path,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
-    dev_hook = SCENARIOS[args.dev](args.seed) if args.dev else None
+    dev_hook = SCENARIOS[args.dev](args.seed) if SCENARIOS is not None and args.dev else None
     ChudApp(dev_hook=dev_hook).run()
     return 0
 


### PR DESCRIPTION
Closes #47

GitHub issue: <https://github.com/Nixotica/chud/issues/47>

`chud --dev <scenario>` and `--seed <path>` are pre-release QA affordances —
they boot the TUI on top of a scripted scenario without driving a real agent.
The flags exist for developers running from a source checkout, but today they
are unconditionally exposed in every install: source, `pip install -e .`,
`python -m build` wheels published by the unstable-release workflow, and the
Nix-built binary. `src/chud/dev.py` even says "This module must not ship in a
released build" but it is currently packaged into every wheel.

Goal: make `--dev` / `--seed` available only when chud is installed from
source (`pip install -e .` or a raw source-tree run). When the published wheel
is installed — unstable prerelease or eventual stable release — neither flag
appears in `chud --help` and neither is recognized by argparse.

---
PR made using [chud](https://github.com/Nixotica/chud).
